### PR TITLE
feat(fiscal): Stampa scontrino fiscale EPSON RT (fpmate.cgi)

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -737,7 +737,7 @@ CREATE TABLE daily_closure_by_method (
 
 ---
 
-### 2.18 `printers` — Stampanti ESC/POS configurate
+### 2.18 `printers` — Stampanti ESC/POS / fiscali configurate
 
 I dati delle stampanti sono configurati in `appConfig.printers` (frontend) e nella collezione
 Directus `printers` (backend). Quando la modalità Directus Pull è attiva, la collezione
@@ -745,24 +745,29 @@ Directus è la **fonte unica di verità** e sovrascrive `printers.config.js` / `
 
 Campi Directus standard abilitati: `status`, `user_created`, `date_created`, `user_updated`, `date_updated`.
 
+Sono supportati tre tipi di stampante:
+- **ESC/POS termiche** (`http` / `tcp` / `file`) — comande, preconti, spostamenti tavolo;
+- **Fiscale Epson RT** (`fpmate`) — scontrini, Z/X report, query stato (protocollo SOAP/HTTP via `fpmate.cgi`).
+
 ```sql
 CREATE TABLE printers (
-    id              VARCHAR(40)     PRIMARY KEY,            -- es. 'cucina', 'bar', 'cassa'
+    id              VARCHAR(40)     PRIMARY KEY,            -- es. 'cucina', 'bar', 'cassa', 'fiscale'
     status          VARCHAR(20)     NOT NULL DEFAULT 'published', -- 'published' | 'archived'
     venue           INTEGER         NOT NULL REFERENCES venues(id) ON DELETE CASCADE,
     name            VARCHAR(80)     NOT NULL,               -- nome visualizzato nella UI
 
     -- ── Endpoint HTTP (per i flussi che usano il print-server via HTTP) ─────
     -- URL del servizio print-server a cui inviare i job via POST /print.
-    -- Usato solo quando la stampante è configurata per connessione HTTP
-    -- (ad es. frontend / Modalità 1). NULL se si usa solo connessione diretta TCP/File.
+    -- Usato da frontend (Modalità 1) e dalla stampante fiscale (connection_type='fpmate').
+    -- NULL se si usa solo connessione diretta TCP/File.
     url             TEXT            NULL,                   -- es. 'http://localhost:3001/print'
 
     -- ── Connessione diretta (per Directus Pull — Modalità 2) ─────────────────
     -- Quando connection_type = 'tcp' o 'file', il print-server in modalità pull
     -- si connette direttamente alla stampante fisica senza passare per l'endpoint HTTP.
+    -- connection_type = 'fpmate' → stampante fiscale Epson RT (fpmate.cgi, SOAP/HTTP).
     -- Se connection_type = 'http' o NULL, viene usata la connessione via URL (sopra).
-    connection_type VARCHAR(10)     NOT NULL DEFAULT 'http', -- 'http' | 'tcp' | 'file'
+    connection_type VARCHAR(10)     NOT NULL DEFAULT 'http', -- 'http' | 'tcp' | 'file' | 'fpmate'
 
     -- Connessione TCP (per connection_type = 'tcp')
     tcp_host        VARCHAR(255)    NULL,                   -- IP/hostname stampante (es. 192.168.1.100)
@@ -772,9 +777,17 @@ CREATE TABLE printers (
     -- Connessione file/USB (per connection_type = 'file')
     file_device     TEXT            NULL DEFAULT '/dev/usb/lp0', -- percorso device USB/parallela
 
+    -- ── Connessione stampante fiscale Epson RT (connection_type = 'fpmate') ─
+    fpmate_host     VARCHAR(255)    NULL,                   -- IP/hostname stampante fiscale (es. 192.168.1.200)
+    fpmate_https    BOOLEAN         NOT NULL DEFAULT FALSE, -- usa HTTPS
+    fpmate_timeout  INTEGER         NULL DEFAULT 30000,     -- timeout fpmate in ms (alto: lo Z report trasmette all'Ade)
+    fpmate_username VARCHAR(255)    NULL,                   -- credenziali web (opzionale)
+    fpmate_password VARCHAR(255)    NULL,                   -- credenziali web (opzionale)
+
     -- ── Routing (per frontend — Modalità 1) ──────────────────────────────────
     -- print_types: quali tipi di lavoro riceve questa stampante.
-    -- Valori ammessi: 'order', 'table_move', 'pre_bill', oppure un tipo custom.
+    -- Valori ammessi: 'order', 'table_move', 'pre_bill', 'fiscal_receipt',
+    -- 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status', oppure un tipo custom.
     -- Array vuoto / NULL = catch-all (riceve tutti i tipi).
     print_types     TEXT[]          NOT NULL DEFAULT '{}',
     -- categories: filtro menu per i lavori di tipo 'order'.
@@ -791,7 +804,7 @@ CREATE TABLE printers (
 ```
 
 > ⚠️ **NON RIMUOVERE i seguenti campi dalla collection `printers`:**
-> `connection_type`, `tcp_host`, `tcp_port`, `tcp_timeout`, `file_device`
+> `connection_type`, `tcp_host`, `tcp_port`, `tcp_timeout`, `file_device`, `fpmate_*`
 >
 > Questi campi **non sono usati dal frontend** (App Cassa / App Cucina) ma sono consumati
 > esclusivamente dal componente **Print Server** (servizio Node.js separato) per aprire
@@ -799,15 +812,20 @@ CREATE TABLE printers (
 >
 > | Campo             | Consumer         | Descrizione                                                        |
 > |-------------------|------------------|--------------------------------------------------------------------|
-> | `connection_type` | **Print Server** | `'http'` → endpoint URL; `'tcp'` → socket TCP; `'file'` → device file USB/parallela |
+> | `connection_type` | **Print Server** | `'http'` → endpoint URL; `'tcp'` → socket TCP; `'file'` → device file USB/parallela; `'fpmate'` → stampante fiscale RT |
 > | `tcp_host`        | **Print Server** | IP/hostname della stampante sulla LAN (modalità `tcp`)             |
 > | `tcp_port`        | **Print Server** | Porta TCP ESC/POS, default 9100 (modalità `tcp`)                   |
 > | `tcp_timeout`     | **Print Server** | Timeout connessione TCP in ms, default 5000 (modalità `tcp`)       |
 > | `file_device`     | **Print Server** | Path device file USB/parallelo, es. `/dev/usb/lp0` (modalità `file`) |
-> | `url`             | Frontend + Print Server | Endpoint HTTP del print-server (modalità `http`). Nullable: obbligatorio solo quando `connection_type = 'http'` |
+> | `fpmate_host`     | **Print Server** | IP/hostname stampante fiscale Epson RT (modalità `fpmate`)         |
+> | `fpmate_https`    | **Print Server** | Usa HTTPS verso fpmate.cgi (modalità `fpmate`)                    |
+> | `fpmate_timeout`  | **Print Server** | Timeout fpmate in ms, default 30000 (modalità `fpmate`)            |
+> | `fpmate_username` | **Print Server** | Credenziali web stampante fiscale, opzionali (modalità `fpmate`)   |
+> | `fpmate_password` | **Print Server** | Credenziali web stampante fiscale, opzionali (modalità `fpmate`)    |
+> | `url`             | Frontend + Print Server | Endpoint HTTP del print-server (modalità `http`/`fpmate`). Nullable: obbligatorio solo quando `connection_type` è `http` o `fpmate` |
 >
-> Rimuovere questi campi da Directus renderebbe inutilizzabili le modalità TCP e File/USB del
-> Print Server, impedendo la stampa diretta senza service intermediary.
+> Rimuovere questi campi da Directus renderebbe inutilizzabili le modalità TCP, File/USB e
+> fiscale del Print Server, impedendo la stampa diretta senza service intermediary.
 
 ---
 
@@ -881,6 +899,10 @@ CREATE INDEX idx_print_jobs_type_status ON print_jobs (print_type, status);
 Ogni record rappresenta un tentativo di emissione di uno scontrino fiscale a chiusura conto.
 Non riutilizza `print_jobs` perché il formato (XML RT) e il ciclo di vita (request/response XML) sono completamente diversi dai lavori ESC/POS.
 
+La stampante fiscale Epson RT comunica via `fpmate.cgi` (SOAP/HTTP); il print-server
+costruisce l'XML dalla richiesta strutturata e restituisce i campi della risposta
+(numero scontrino, matricola, numero Z) che vengono persistiti qui per audit.
+
 ```sql
 CREATE TABLE fiscal_receipts (
     id                  UUID        PRIMARY KEY,   -- UUID v7 generato client-side (time-ordered)
@@ -897,6 +919,15 @@ CREATE TABLE fiscal_receipts (
     orders              TEXT,                      -- JSON snapshot voci (name/qty/unitPrice)
     xml_request         TEXT,                      -- Payload XML inviato alla stampante
     xml_response        TEXT,                      -- Risposta XML ricevuta dalla stampante (null se non ancora ricevuta)
+    -- Risposta fpmate (addInfo) — popolata dal print-server alla conferma dello scontrino
+    fiscal_receipt_number   TEXT,                 -- Numero progressivo scontrino (fiscalReceiptNumber)
+    fiscal_receipt_amount   TEXT,                  -- Importo stampato (fiscalReceiptAmount, formato italiano "13,00")
+    fiscal_receipt_date     TEXT,                  -- Data scontrino (fiscalReceiptDate, "21/04/2023")
+    fiscal_receipt_time     TEXT,                  -- Ora scontrino (fiscalReceiptTime, "11:35")
+    receipt_iso_date_time  TEXT,                   -- ISO datetime scontrino (receiptISODateTime, "20230421T113500")
+    z_rep_number            TEXT,                 -- Numero Z report corrente (zRepNumber)
+    serial_number           TEXT,                 -- Matricola stampante (serialNumber)
+    printer_status          TEXT,                 -- Stato stampante (printerStatus)
     status              TEXT        NOT NULL DEFAULT 'pending'
                                     CHECK (status IN ('pending','sent','ok','error')),
     timestamp           TIMESTAMPTZ NOT NULL DEFAULT NOW(),  -- Istante della richiesta (non della chiusura conto)
@@ -913,6 +944,8 @@ CREATE INDEX idx_fiscal_receipts_table        ON fiscal_receipts ("table");
 CREATE INDEX idx_fiscal_receipts_bill_session ON fiscal_receipts (bill_session);
 CREATE INDEX idx_fiscal_receipts_status       ON fiscal_receipts (status);
 CREATE INDEX idx_fiscal_receipts_timestamp    ON fiscal_receipts (timestamp DESC);
+CREATE INDEX idx_fiscal_receipts_serial       ON fiscal_receipts (serial_number);
+CREATE INDEX idx_fiscal_receipts_z_rep         ON fiscal_receipts (z_rep_number);
 ```
 
 ---

--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -939,7 +939,9 @@ CREATE TABLE fiscal_receipts (
     serial_number           TEXT,                 -- Matricola stampante (serialNumber)
     printer_status          TEXT,                 -- Stato stampante (printerStatus)
     status              TEXT        NOT NULL DEFAULT 'pending'
-                                    CHECK (status IN ('pending','sent','ok','error')),
+                                    CHECK (status IN ('pending','done','error','void')),
+                                    -- Stati ciclo scontrino fiscale: pending (richiesta in attesa),
+                                    -- done (emesso/stampato), error (fallito), void (annullato).
     timestamp           TIMESTAMPTZ NOT NULL DEFAULT NOW(),  -- Istante della richiesta (non della chiusura conto)
     -- Directus standard fields
     date_created        TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -896,8 +896,14 @@ CREATE INDEX idx_print_jobs_type_status ON print_jobs (print_type, status);
 
 ### 2.20 `fiscal_receipts` — Comandi stampante fiscale (scontrini RT)
 
-Ogni record rappresenta un tentativo di emissione di uno scontrino fiscale a chiusura conto.
+Ogni record rappresenta un tentativo di emissione di un documento fiscale a chiusura conto.
 Non riutilizza `print_jobs` perché il formato (XML RT) e il ciclo di vita (request/response XML) sono completamente diversi dai lavori ESC/POS.
+
+Supporta i documenti fiscali RT generati dal tab "Fiscale RT" del Cruscotto Cassa:
+scontrino (`fiscal_receipt`), reso (`fiscal_refund`) e annullo (`fiscal_void`). La colonna
+`operation_type` distingue il tipo di documento; per gli annulli, `void_ref_id` punta allo
+scontrino originale annullato (i cui riferimenti Z/numero/data/matricola sono già memorizzati
+nei campi `z_rep_number`/`fiscal_receipt_number`/`fiscal_receipt_date`/`serial_number`).
 
 La stampante fiscale Epson RT comunica via `fpmate.cgi` (SOAP/HTTP); il print-server
 costruisce l'XML dalla richiesta strutturata e restituisce i campi della risposta
@@ -917,9 +923,13 @@ CREATE TABLE fiscal_receipts (
                                                    -- Per conti dallo storico: include bill.totalDiscount per allineamento con la cassa live
     payment_methods     TEXT,                      -- JSON array di stringhe
     orders              TEXT,                      -- JSON snapshot voci (name/qty/unitPrice)
+    operation_type      TEXT        NOT NULL DEFAULT 'receipt'
+                                    CHECK (operation_type IN ('receipt','refund','void','duplicate','cash','status','z_report','x_report','drawer')),
+    void_ref_id         UUID        REFERENCES fiscal_receipts(id) ON DELETE SET NULL,
+                                                   -- Scontrino originale annullato (solo per operation_type = 'void')
     xml_request         TEXT,                      -- Payload XML inviato alla stampante
     xml_response        TEXT,                      -- Risposta XML ricevuta dalla stampante (null se non ancora ricevuta)
-    -- Risposta fpmate (addInfo) — popolata dal print-server alla conferma dello scontrino
+    -- Risposta fpmate (addInfo) — popolata dal print-server alla conferma del documento
     fiscal_receipt_number   TEXT,                 -- Numero progressivo scontrino (fiscalReceiptNumber)
     fiscal_receipt_amount   TEXT,                  -- Importo stampato (fiscalReceiptAmount, formato italiano "13,00")
     fiscal_receipt_date     TEXT,                  -- Data scontrino (fiscalReceiptDate, "21/04/2023")
@@ -946,6 +956,8 @@ CREATE INDEX idx_fiscal_receipts_status       ON fiscal_receipts (status);
 CREATE INDEX idx_fiscal_receipts_timestamp    ON fiscal_receipts (timestamp DESC);
 CREATE INDEX idx_fiscal_receipts_serial       ON fiscal_receipts (serial_number);
 CREATE INDEX idx_fiscal_receipts_z_rep         ON fiscal_receipts (z_rep_number);
+CREATE INDEX idx_fiscal_receipts_operation    ON fiscal_receipts (operation_type);
+CREATE INDEX idx_fiscal_receipts_void_ref      ON fiscal_receipts (void_ref_id);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -256,6 +256,16 @@ Funzionalità disponibile sia in **cassa live** (al momento della chiusura del c
 - **Report X** (anteprima giornaliera senza reset): totale incassato, breakdown per metodo di pagamento, mance, sconti, numero conti, scontrino medio, coperti serviti
 - **Chiusura di giornata (Report Z)**: archivia il riepilogo, azzera transazioni e movimenti, aggiorna il saldo cassa
 
+### 🖨️ Operazioni Fiscali Stampante RT (tab "Fiscale RT")
+Il Cruscotto Cassa espone un tab dedicato alle operazioni fiscali della stampante Epson RT (protocollo fpmate / ePOS Fiscal Print). Tutte transitano per il print-server che genera l'XML e dialoga con `fpmate.cgi`:
+- **Stato stampante RT** — giornata aperta, file da inviare all'Agenzia delle Entrate, file rifiutati, stato principale, matricola, scadenza certificato
+- **Lettura X fiscale** — stampa il report finanziario sulla stampante RT (in aggiunta alla rielaborazione locale)
+- **Lettura Z fiscale** — stampa la chiusura giornaliera fiscale sulla stampante RT (trasmette all'Agenzia delle Entrate)
+- **Apri cassetto** — apertura del cassetto contanti collegato alla stampante fiscale
+- **Duplicato scontrino** — ristampa dell'ultimo scontrino commerciale (documento di gestione, letto dall'MPD/EJ)
+- **Movimento cassa fiscale** — versamento/prelievo registrato nella memoria fiscale RT (contanti o assegni)
+- **Annullo scontrino (Void)** — selezione di uno scontrino già emesso e invio del documento di annullo commerciale; i riferimenti (Z, numero, data, matricola) sono letti dalla entry `fiscal_receipts` dell'originale
+
 ### 🗒️ Storico Conti
 - Vista dedicata con tutti i conti chiusi della sessione
 - Riepilogo per sessione di conto: tavolo, coperti, orario chiusura, totale, mance, sconti

--- a/print-server/.env.example
+++ b/print-server/.env.example
@@ -40,6 +40,27 @@ PRINT_SERVER_NAME=ESC/POS Print Server
 # PRINTER_2_TYPE=file
 # PRINTER_2_DEVICE=/dev/usb/lp0
 
+# ── Stampante fiscale Epson RT (fpmate.cgi) ──────────────────────────────────
+#
+# La stampante fiscale Epson RT espone un web service SOAP/HTTP (fpmate.cgi)
+# per l'emissione di documenti fiscali (scontrini, Z report, ecc.).
+# Configurarla come tipo 'fpmate': il print-server costruisce l'XML fiscale
+# e lo invia a http://<host>/cgi-bin/fpmate.cgi.
+#
+# PRINTER_3_ID=fiscale
+# PRINTER_3_NAME=Stampante Fiscale
+# PRINTER_3_TYPE=fpmate
+# PRINTER_3_HOST=192.168.1.200
+# # Porta HTTP della stampante (opzionale; default: 80/443)
+# # PRINTER_3_PORT=80
+# # Timeout fpmate in ms (default: 30000 — lo Z report trasmette all'Ade)
+# # PRINTER_3_TIMEOUT=30000
+# # Usa HTTPS (default: false)
+# # PRINTER_3_HTTPS=false
+# # Credenziali web (opzionale, se il web server della stampante è protetto)
+# # PRINTER_3_USERNAME=
+# # PRINTER_3_PASSWORD=
+
 # ── Modalità Directus Pull (opzionale) ────────────────────────────────────────
 #
 # Se impostati DIRECTUS_URL e DIRECTUS_TOKEN, il print-server si connette

--- a/print-server/README.md
+++ b/print-server/README.md
@@ -379,9 +379,25 @@ app-cassa ──POST /print (printType=fiscal_receipt)──► print-server
 | printType | Descrizione |
 |---|---|
 | `fiscal_receipt` | Scontrino fiscale (documento commerciale). Job: `orders[].items[]`, `payments[]`, `totalAmount` |
+| `fiscal_refund` | Documento di reso commerciale (RESO MERCE). Job come `fiscal_receipt` + `receiptRef?` (collegamento all'originale) |
+| `fiscal_void` | Documento di annullo commerciale (VOID). Job: `receiptRef { zRepNumber, fiscalReceiptNumber, date, serialNumber }` |
 | `fiscal_z_report` | Chiusura giornaliera (Z report). Trasmette i dati all'Agenzia delle Entrate |
 | `fiscal_x_report` | Report finanziario giornaliero (X report, non fiscale) |
 | `fiscal_status` | Query stato stampante (`statusType`: `'0'` base, `'1'` RT) |
+| `fiscal_duplicate` | Ristampa ultimo scontrino (documento di gestione, letto dall'MPD/EJ) |
+| `fiscal_drawer` | Apertura cassetto contanti collegato alla stampante fiscale |
+| `fiscal_cash` | Movimento cassa fiscale (versamento/prelievo). Job: `direction` (`in`/`out`), `amount`, `form?` (`cash`/`cheque`) |
+
+**Operazioni del cassiere (UI Cruscotto Cassa → tab "Fiscale RT"):**
+
+- **Stato stampante** — interrogazione stato RT (giornata aperta, file da inviare all'Agenzia delle Entrate, scadenza certificato, matricola).
+- **Lettura X / Z fiscale** — pulsanti dedicati nei tab "Lettura X" e "Lettura Z" inviano il job alla stampante RT (oltre alla rielaborazione locale).
+- **Apri cassetto** — apertura cassetto contanti (`openDrawer`).
+- **Duplicato scontrino** — ristampa dell'ultimo scontrino commerciale (`printDuplicateReceipt`, documento di gestione).
+- **Movimento cassa fiscale** — versamento/prelievo registrato nella memoria fiscale RT (`printRecCash`).
+- **Annullo scontrino (Void)** — selezione di uno scontrino emesso e invio del documento di annullo commerciale (`VOID zzzz nnnn ddmmyyyy sssssssssss`). I riferimenti (zRepNumber, fiscalReceiptNumber, date, serialNumber) sono letti dalla entry `fiscal_receipts` dell'originale.
+
+Tutte le operazioni transitano per il print-server; il browser invia solo il job strutturato.
 
 **Configurazione** (`printers.config.js`):
 
@@ -496,7 +512,7 @@ Riceve un job JSON, lo converte in ESC/POS (o XML fiscale) e lo invia alla stamp
 
 | Campo | Tipo | Descrizione |
 |---|---|---|
-| `printType` | `string` | **Obbligatorio.** `'order'` \| `'table_move'` \| `'pre_bill'` \| `'fiscal_receipt'` \| `'fiscal_z_report'` \| `'fiscal_x_report'` \| `'fiscal_status'` |
+| `printType` | `string` | **Obbligatorio.** `'order'` \| `'table_move'` \| `'pre_bill'` \| `'fiscal_receipt'` \| `'fiscal_refund'` \| `'fiscal_void'` \| `'fiscal_z_report'` \| `'fiscal_x_report'` \| `'fiscal_status'` \| `'fiscal_duplicate'` \| `'fiscal_drawer'` \| `'fiscal_cash'` |
 | `printerId` | `string` | ID stampante. Se assente/non trovato → prima stampante |
 | `jobId` | `string` | Identificatore job (restituito in risposta) |
 
@@ -608,7 +624,7 @@ printers: [
     printTypes: ['pre_bill', 'table_move'] },
   { id: 'fiscale', name: 'Stampante Fiscale',
     connectionType: 'fpmate', url: 'http://localhost:3001/print',
-    printTypes: ['fiscal_receipt', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status'] },
+    printTypes: ['fiscal_receipt', 'fiscal_refund', 'fiscal_void', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status', 'fiscal_duplicate', 'fiscal_drawer', 'fiscal_cash'] },
 ],
 ```
 

--- a/print-server/README.md
+++ b/print-server/README.md
@@ -354,6 +354,86 @@ module.exports = {
 
 ---
 
+## Stampante fiscale Epson RT (fpmate)
+
+Oltre alle stampanti termiche ESC/POS (TCP/file), il print-server supporta le
+**stampanti fiscali Epson RT** tramite il web service `fpmate.cgi` integrato
+nella stampante. Il protocollo è SOAP/HTTP con XML (Fiscal ePOS-Print), diverso
+dall'ESC/POS raw: per questo la stampante fiscale va configurata con
+`type: 'fpmate'`.
+
+```
+app-cassa ──POST /print (printType=fiscal_receipt)──► print-server
+                                                            │
+                                              buildFiscalXml (formatters/fiscal_receipt.js)
+                                                            │
+                                                  HTTP POST SOAP
+                                                            ▼
+                                    http://<host>/cgi-bin/fpmate.cgi  (stampante fiscale RT)
+                                                            │
+                                  risposta XML: fiscalReceiptNumber, amount, date, zRepNumber, serialNumber
+```
+
+**Tipi di stampa fiscali** (`printType`):
+
+| printType | Descrizione |
+|---|---|
+| `fiscal_receipt` | Scontrino fiscale (documento commerciale). Job: `orders[].items[]`, `payments[]`, `totalAmount` |
+| `fiscal_z_report` | Chiusura giornaliera (Z report). Trasmette i dati all'Agenzia delle Entrate |
+| `fiscal_x_report` | Report finanziario giornaliero (X report, non fiscale) |
+| `fiscal_status` | Query stato stampante (`statusType`: `'0'` base, `'1'` RT) |
+
+**Configurazione** (`printers.config.js`):
+
+```js
+module.exports = {
+  printers: [
+    // ... stampanti cucina/bar ...
+    { id: 'fiscale', name: 'Stampante Fiscale', type: 'fpmate', host: '192.168.1.200', timeout: 30000 },
+  ],
+};
+```
+
+Oppure via variabili d'ambiente `PRINTER_<N>_TYPE=fpmate` (vedi `.env.example`).
+
+**Job `fiscal_receipt` — payload di esempio:**
+
+```json
+{
+  "printType": "fiscal_receipt",
+  "printerId": "fiscale",
+  "jobId": "0192-...",
+  "orders": [
+    { "items": [
+      { "name": "Panino", "quantity": 2, "unitPrice": 6.5, "department": 1 },
+      { "name": "Caffè", "quantity": 1, "unitPrice": 1.0 }
+    ] }
+  ],
+  "payments": [
+    { "label": "Contanti", "amount": 13 }
+  ],
+  "totalAmount": 14,
+  "timestamp": "2024-01-01T20:30:00.000Z"
+}
+```
+
+Il `paymentType` viene determinato automaticamente dall'etichetta del pagamento
+(`Contanti` → `0`, `Carta`/`Bancomat`/`Pos` → `2`). I pagamenti parziali sono
+supportati (più elementi in `payments[]`).
+
+**Note di sicurezza fiscale:**
+- I job fiscali sono **serializzati** per stampante (come gli altri job): non
+  viene mai emesso uno scontrino mentre è in corso uno Z report.
+- La risposta della stampante (numero scontrino, matricola, numero Z) viene
+  restituita al chiamante e, lato app-cassa, persistita in `fiscal_receipts`
+  per audit.
+- L'eventuale timeout (default 30s, configurabile) va tenuto alto per lo Z
+  report, che trasmette dati all'Agenzia delle Entrate.
+
+Riferimento protocollo: *ePOS Fiscal Print Solution Development Guide* (Epson Italia).
+
+---
+
 ## Variabili d'ambiente — riepilogo completo
 
 | Variabile | Default | Descrizione |
@@ -362,7 +442,11 @@ module.exports = {
 | `PRINT_SERVER_NAME` | `ESC/POS Print Server` | Nome nei log |
 | `PRINT_SERVER_API_KEY` | *(vuoto)* | Richiede `x-api-key` su `POST /print` |
 | `CORS_ALLOWED_ORIGINS` | *(vuoto — tutte)* | Origini CORS consentite (virgola separata) |
-| `PRINTER_<N>_*` | — | Configurazione stampante N (vedi sopra) |
+| `PRINTER_<N>_*` | — | Configurazione stampante N (TCP/file/fpmate — vedi sopra) |
+| `PRINTER_<N>_TYPE` | `tcp` | `tcp` \| `file` \| `fpmate` (stampante fiscale RT) |
+| `PRINTER_<N>_HTTPS` | `false` | *(fpmate)* Usa HTTPS |
+| `PRINTER_<N>_USERNAME` | *(vuoto)* | *(fpmate)* Credenziali web (opzionale) |
+| `PRINTER_<N>_PASSWORD` | *(vuoto)* | *(fpmate)* Credenziali web (opzionale) |
 | `DIRECTUS_URL` | *(vuoto — disabilitato)* | URL Directus per modalità pull |
 | `DIRECTUS_TOKEN` | *(vuoto)* | Static token Directus |
 | `DIRECTUS_VENUE_ID` | *(vuoto — tutti)* | Filtro venue ID |
@@ -408,22 +492,59 @@ Output di avvio con Modalità 2 abilitata:
 
 ### `POST /print`
 
-Riceve un job JSON, lo converte in ESC/POS e lo invia alla stampante.
+Riceve un job JSON, lo converte in ESC/POS (o XML fiscale) e lo invia alla stampante.
 
 | Campo | Tipo | Descrizione |
 |---|---|---|
-| `printType` | `string` | **Obbligatorio.** `'order'` \| `'table_move'` \| `'pre_bill'` |
+| `printType` | `string` | **Obbligatorio.** `'order'` \| `'table_move'` \| `'pre_bill'` \| `'fiscal_receipt'` \| `'fiscal_z_report'` \| `'fiscal_x_report'` \| `'fiscal_status'` |
 | `printerId` | `string` | ID stampante. Se assente/non trovato → prima stampante |
 | `jobId` | `string` | Identificatore job (restituito in risposta) |
 
-**Risposta di successo (200):**
+**Risposta di successo (200) — job ESC/POS:**
 ```json
 { "ok": true, "jobId": "job_<uuid>" }
+```
+
+**Risposta di successo (200) — job fiscale:** include la risposta parsata della
+stampante fiscale (numero scontrino, importo, data/ora, numero Z, matricola):
+```json
+{
+  "ok": true,
+  "jobId": "job_<uuid>",
+  "fiscal": {
+    "success": true,
+    "code": "",
+    "status": "2",
+    "addInfo": {
+      "fiscalReceiptNumber": "5",
+      "fiscalReceiptAmount": "13,00",
+      "fiscalReceiptDate": "21/04/2023",
+      "fiscalReceiptTime": "11:35",
+      "receiptISODateTime": "20230421T113500",
+      "zRepNumber": "39",
+      "serialNumber": "99IEB004001"
+    },
+    "raw": "<response ...>"
+  }
+}
 ```
 
 **Risposta di errore (400/500):**
 ```json
 { "ok": false, "error": "messaggio di errore" }
+```
+
+### `GET /printers`
+
+Restituisce l'elenco delle stampanti configurate (senza credenziali):
+```json
+{
+  "ok": true,
+  "printers": [
+    { "id": "cucina", "name": "Cucina", "type": "tcp", "host": "192.168.1.100", "port": 9100 },
+    { "id": "fiscale", "name": "Stampante Fiscale", "type": "fpmate", "host": "192.168.1.200", "port": null, "https": false }
+  ]
+}
 ```
 
 ---
@@ -433,14 +554,16 @@ Riceve un job JSON, lo converte in ESC/POS e lo invia alla stampante.
 ```
 print-server/
 ├── server.js              # Entry point: server HTTP Express
-├── printer.js             # Multi-printer dispatch (TCP / file, coda serializzata)
+├── printer.js             # Multi-printer dispatch (TCP / file / fpmate, coda serializzata)
 ├── build-buffer.js        # Seleziona il formatter ESC/POS corretto
+├── fpmate-client.js       # Transport HTTP/SOAP per stampante fiscale Epson RT (fpmate.cgi)
 ├── directus-client.js     # Modalità 2: Directus Pull (SDK + WebSocket + polling)
 ├── printers.config.js     # ← Configurare qui le stampanti del locale
-├── formatters/            # ← FONTE UNICA dei formatter ESC/POS (vedi sotto)
+├── formatters/            # ← FONTE UNICA dei formatter (ESC/POS + fiscale)
 │   ├── order.js           # Comanda cucina/bar
 │   ├── table_move.js      # Spostamento tavolo
-│   └── pre_bill.js        # Preconto
+│   ├── pre_bill.js        # Preconto
+│   └── fiscal_receipt.js  # XML fiscale (scontrino, Z/X report, stato)
 ├── Dockerfile
 ├── docker-compose.yml
 ├── .env.example
@@ -483,8 +606,16 @@ printers: [
     printTypes: ['order'], categories: ['Antipasti', 'Primi'] },
   { id: 'cassa',  name: 'Cassa',  url: 'http://localhost:3001/print',
     printTypes: ['pre_bill', 'table_move'] },
+  { id: 'fiscale', name: 'Stampante Fiscale',
+    connectionType: 'fpmate', url: 'http://localhost:3001/print',
+    printTypes: ['fiscal_receipt', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status'] },
 ],
 ```
+
+La stampante fiscale usa `connectionType: 'fpmate'` e punta allo stesso endpoint
+`/print` del print-server. Il composable `useFiscalPrint` individua la stampante
+fiscale configurata, invia il job strutturato (`orders`, `payments`) e aggiorna
+lo store `fiscalReceipts` con la risposta (numero scontrino, matricola, …).
 
 ### Modalità 2/3 (Directus Pull/Hook)
 

--- a/print-server/__tests__/fiscal_receipt.test.js
+++ b/print-server/__tests__/fiscal_receipt.test.js
@@ -263,6 +263,27 @@ describe('formatFiscalRefund', () => {
     expect(xml).toContain('message="REFUND 0039 0005 31012024 99IEB004001"');
   });
 
+  it('rejects a partial receiptRef instead of emitting a malformed REFUND line', () => {
+    // Se mancano campi obbligatori del riferimento, la riga REFUND con campi
+    // vuoti/zerati verrebbe rifiutata dalla stampante o collegherebbe il reso al
+    // documento sbagliato: bisogna fallire a monte con un messaggio chiaro.
+    const partial = { zRepNumber: '39', fiscalReceiptNumber: '5', date: '31/01/2024' /* serialNumber mancante */ };
+    expect(() => formatFiscalRefund({ ...refundJob, receiptRef: partial }))
+      .toThrow(/receiptRef incompleto.*serialNumber/);
+  });
+
+  it('rejects a receiptRef with a malformed date', () => {
+    // Data presente ma non valida: normalizeRefDate non restituisce 8 cifre.
+    const bad = { zRepNumber: '39', fiscalReceiptNumber: '5', date: 'non-una-data', serialNumber: '99IEB004001' };
+    expect(() => formatFiscalRefund({ ...refundJob, receiptRef: bad }))
+      .toThrow(/receiptRef incompleto.*date/);
+  });
+
+  it('does not prepend a REFUND line when receiptRef is absent (unreferenced refund)', () => {
+    const xml = formatFiscalRefund(refundJob);
+    expect(xml).not.toContain('REFUND ');
+  });
+
   it('throws when no refund items are provided', () => {
     expect(() => formatFiscalRefund({ orders: [], payments: [{ label: 'Contanti', amount: 1 }] })).toThrow();
   });

--- a/print-server/__tests__/fiscal_receipt.test.js
+++ b/print-server/__tests__/fiscal_receipt.test.js
@@ -355,6 +355,14 @@ describe('extractTagContent', () => {
   it('tolerates attributes on the opening tag', () => {
     expect(extractTagContent('<response success="true"><lastCommand>74</lastCommand></response>', 'lastCommand')).toBe('74');
   });
+  it('escapes regex metacharacters in the tag name', () => {
+    expect(extractTagContent('<a.b+c>dollar.content</a.b+c>', 'a.b+c')).toBe('dollar.content');
+    expect(extractTagContent('<a>(x)<value>ok</value></a>(x)', 'value')).toBe('ok');
+  });
+  it('tolerates a namespace prefix on open and close tags', () => {
+    expect(extractTagContent('<ns:foo>bar</ns:foo>', 'foo')).toBe('bar');
+    expect(extractTagContent('<x:status code="1">ok</x:status>', 'status')).toBe('ok');
+  });
 });
 
 describe('parseFiscalResponse', () => {

--- a/print-server/__tests__/fiscal_receipt.test.js
+++ b/print-server/__tests__/fiscal_receipt.test.js
@@ -1,0 +1,301 @@
+/**
+ * @file __tests__/fiscal_receipt.test.js
+ * @description Unit test per i formatter XML fiscali (formatters/fiscal_receipt.js)
+ * e per il client fpmate (fpmate-client.js): generazione XML, envelope SOAP,
+ * parsing risposte, build URL.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  buildFiscalXml,
+  formatFiscalReceipt,
+  formatZReport,
+  formatXReport,
+  formatStatusQuery,
+  formatAmount,
+  formatQuantity,
+  paymentTypeFromLabel,
+  escXml,
+} = require('../formatters/fiscal_receipt.js');
+const {
+  wrapSoapEnvelope,
+  buildFpmateUrl,
+  parseFiscalResponse,
+  extractTagContent,
+} = require('../fpmate-client.js');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const minimalReceiptJob = {
+  printType: 'fiscal_receipt',
+  orders: [{ items: [{ name: 'Panino', quantity: 2, unitPrice: 6.5, department: 1 }] }],
+  payments: [{ label: 'Contanti', amount: 13 }],
+  totalAmount: 13,
+};
+
+// ── formatFiscalReceipt ──────────────────────────────────────────────────────
+
+describe('formatFiscalReceipt', () => {
+  it('builds a valid printerFiscalReceipt XML for a minimal sale', () => {
+    const xml = formatFiscalReceipt(minimalReceiptJob);
+    expect(xml).toContain('<printerFiscalReceipt>');
+    expect(xml).toContain('</printerFiscalReceipt>');
+    expect(xml).toContain('<beginFiscalReceipt operator="1" />');
+    expect(xml).toContain('<endFiscalReceipt operator="1" />');
+    // printRecItem with comma decimal separators (Italian convention)
+    expect(xml).toContain('<printRecItem operator="1" description="Panino" quantity="2,000" unitPrice="6,50" department="1" justification="1" />');
+    // printRecTotal cash → paymentType 0
+    expect(xml).toContain('<printRecTotal operator="1" description="Contanti" payment="13,00" paymentType="0" justification="2" />');
+  });
+
+  it('uses paymentType 2 for card/electronic payments', () => {
+    const xml = formatFiscalReceipt({
+      orders: [{ items: [{ name: 'Caffè', quantity: 1, unitPrice: 1 }] }],
+      payments: [{ label: 'Bancomat', amount: 1 }],
+    });
+    expect(xml).toContain('paymentType="2"');
+  });
+
+  it('emits one printRecTotal per partial payment', () => {
+    const xml = formatFiscalReceipt({
+      orders: [{ items: [{ name: 'Pizza', quantity: 1, unitPrice: 10 }] }],
+      payments: [
+        { label: 'Contanti', amount: 6 },
+        { label: 'Carta', amount: 4 },
+      ],
+    });
+    const totals = xml.match(/<printRecTotal /g) || [];
+    expect(totals.length).toBe(2);
+    expect(xml).toContain('payment="6,00"');
+    expect(xml).toContain('payment="4,00"');
+  });
+
+  it('defaults department to 1 when not specified', () => {
+    const xml = formatFiscalReceipt({
+      orders: [{ items: [{ name: 'Acqua', quantity: 1, unitPrice: 2 }] }],
+      payments: [{ label: 'Contanti', amount: 2 }],
+    });
+    expect(xml).toContain('department="1"');
+  });
+
+  it('escapes XML special characters in item names and payment labels', () => {
+    const xml = formatFiscalReceipt({
+      orders: [{ items: [{ name: 'Panino <vegano> & "speciale"', quantity: 1, unitPrice: 5 }] }],
+      payments: [{ label: "Carta d'acquisto", amount: 5 }],
+    });
+    expect(xml).not.toContain('<vegano>');
+    expect(xml).toContain('&lt;vegano&gt;');
+    expect(xml).toContain('&amp;');
+    expect(xml).toContain('&quot;');
+    expect(xml).toContain('&apos;');
+  });
+
+  it('includes header and trailer lines around beginFiscalReceipt', () => {
+    const xml = formatFiscalReceipt({
+      orders: [{ items: [{ name: 'X', quantity: 1, unitPrice: 1 }] }],
+      payments: [{ label: 'Contanti', amount: 1 }],
+      headerLines: ['Pizzeria Da Mario'],
+      trailerLines: ['Grazie e arrivederci'],
+    });
+    // header messageType 1 must precede beginFiscalReceipt
+    const headerIdx = xml.indexOf('messageType="1"');
+    const beginIdx = xml.indexOf('<beginFiscalReceipt');
+    expect(headerIdx).toBeGreaterThan(-1);
+    expect(beginIdx).toBeGreaterThan(-1);
+    expect(headerIdx).toBeLessThan(beginIdx);
+    expect(xml).toContain('messageType="3"');
+    expect(xml).toContain('Pizzeria Da Mario');
+    expect(xml).toContain('Grazie e arrivederci');
+  });
+
+  it('throws when there are no sale items', () => {
+    expect(() => formatFiscalReceipt({
+      orders: [{ items: [] }],
+      payments: [{ label: 'Contanti', amount: 1 }],
+    })).toThrow(/almeno una voce/i);
+  });
+
+  it('throws when there are no payments', () => {
+    expect(() => formatFiscalReceipt({
+      orders: [{ items: [{ name: 'X', quantity: 1, unitPrice: 1 }] }],
+      payments: [],
+    })).toThrow(/almeno un pagamento/i);
+  });
+
+  it('accepts a custom operator', () => {
+    const xml = formatFiscalReceipt({
+      operator: 5,
+      orders: [{ items: [{ name: 'X', quantity: 1, unitPrice: 1 }] }],
+      payments: [{ label: 'Contanti', amount: 1 }],
+    });
+    expect(xml).toContain('operator="5"');
+  });
+});
+
+// ── Reports ──────────────────────────────────────────────────────────────────
+
+describe('formatZReport / formatXReport', () => {
+  it('builds a Z report with default 30s timeout', () => {
+    const xml = formatZReport({});
+    expect(xml).toContain('<printerFiscalReport>');
+    expect(xml).toContain('<printZReport operator="1" timeout="30000" />');
+  });
+
+  it('builds an X report without timeout attribute', () => {
+    const xml = formatXReport({});
+    expect(xml).toContain('<printXReport operator="1" />');
+    expect(xml).not.toContain('timeout');
+  });
+
+  it('honours a custom timeout and operator on Z report', () => {
+    const xml = formatZReport({ operator: 2, timeout: 60000 });
+    expect(xml).toContain('operator="2" timeout="60000"');
+  });
+});
+
+// ── Status query ─────────────────────────────────────────────────────────────
+
+describe('formatStatusQuery', () => {
+  it('defaults to basic status (statusType 0)', () => {
+    const xml = formatStatusQuery({});
+    expect(xml).toContain('<printerCommand>');
+    expect(xml).toContain('statusType="0"');
+  });
+
+  it('supports RT status (statusType 1)', () => {
+    const xml = formatStatusQuery({ statusType: '1' });
+    expect(xml).toContain('statusType="1"');
+  });
+});
+
+// ── buildFiscalXml dispatch ──────────────────────────────────────────────────
+
+describe('buildFiscalXml dispatch', () => {
+  it('routes each fiscal printType to its formatter', () => {
+    expect(buildFiscalXml({ printType: 'fiscal_receipt', orders: [{ items: [{ name: 'X', quantity: 1, unitPrice: 1 }] }], payments: [{ label: 'Contanti', amount: 1 }] })).toContain('printerFiscalReceipt');
+    expect(buildFiscalXml({ printType: 'fiscal_z_report' })).toContain('printZReport');
+    expect(buildFiscalXml({ printType: 'fiscal_x_report' })).toContain('printXReport');
+    expect(buildFiscalXml({ printType: 'fiscal_status' })).toContain('queryPrinterStatus');
+  });
+
+  it('throws for unsupported printType', () => {
+    expect(() => buildFiscalXml({ printType: 'bogus' })).toThrow(/Tipo fiscale non supportato/);
+  });
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+describe('format helpers', () => {
+  it('formatAmount uses Italian comma separator', () => {
+    expect(formatAmount(13)).toBe('13,00');
+    expect(formatAmount(6.5)).toBe('6,50');
+    expect(formatAmount(0)).toBe('0,00');
+    expect(formatAmount('12.34')).toBe('12,34');
+  });
+
+  it('formatQuantity uses 3 decimals', () => {
+    expect(formatQuantity(2)).toBe('2,000');
+    expect(formatQuantity(1.5)).toBe('1,500');
+    expect(formatQuantity(0)).toBe('1,000'); // zero → fallback 1
+    expect(formatQuantity('1.234')).toBe('1,234');
+  });
+
+  it('paymentTypeFromLabel detects electronic payments', () => {
+    expect(paymentTypeFromLabel('Contanti')).toBe('0');
+    expect(paymentTypeFromLabel('Bancomat')).toBe('2');
+    expect(paymentTypeFromLabel('Pos/Carta')).toBe('2');
+    expect(paymentTypeFromLabel('Visa')).toBe('2');
+  });
+
+  it('escXml escapes all required characters', () => {
+    expect(escXml('<>&"\'')).toBe('&lt;&gt;&amp;&quot;&apos;');
+  });
+});
+
+// ── fpmate-client ────────────────────────────────────────────────────────────
+
+describe('wrapSoapEnvelope', () => {
+  it('wraps inner XML in a SOAP envelope', () => {
+    const out = wrapSoapEnvelope('<printerCommand/>');
+    expect(out).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(out).toContain('<s:Envelope');
+    expect(out).toContain('<s:Body><printerCommand/></s:Body>');
+    expect(out.endsWith('</s:Envelope>')).toBe(true);
+  });
+});
+
+describe('buildFpmateUrl', () => {
+  it('builds the base URL without timeout', () => {
+    expect(buildFpmateUrl('192.168.1.200')).toBe('http://192.168.1.200/cgi-bin/fpmate.cgi');
+  });
+  it('appends timeout and port and https', () => {
+    expect(buildFpmateUrl('10.0.0.5', { port: 443, https: true, timeout: 12000 }))
+      .toBe('https://10.0.0.5:443/cgi-bin/fpmate.cgi?timeout=12000');
+  });
+});
+
+describe('extractTagContent', () => {
+  it('returns the inner text of a tag', () => {
+    expect(extractTagContent('<a><b>hello</b></a>', 'b')).toBe('hello');
+  });
+  it('returns null when the tag is absent', () => {
+    expect(extractTagContent('<a></a>', 'b')).toBeNull();
+  });
+  it('tolerates attributes on the opening tag', () => {
+    expect(extractTagContent('<response success="true"><lastCommand>74</lastCommand></response>', 'lastCommand')).toBe('74');
+  });
+});
+
+describe('parseFiscalResponse', () => {
+  it('parses a successful commercial document response', () => {
+    const xml = [
+      '<response success="true" code="" status="2">',
+      '<addInfo>',
+      '<elementList>lastCommand,printerStatus,fiscalReceiptNumber,fiscalReceiptAmount,fiscalReceiptDate,fiscalReceiptTime,receiptISODateTime,zRepNumber,serialNumber</elementList>',
+      '<lastCommand>74</lastCommand>',
+      '<printerStatus>20010</printerStatus>',
+      '<fiscalReceiptNumber>5</fiscalReceiptNumber>',
+      '<fiscalReceiptAmount>13,00</fiscalReceiptAmount>',
+      '<fiscalReceiptDate>21/04/2023</fiscalReceiptDate>',
+      '<fiscalReceiptTime>11:35</fiscalReceiptTime>',
+      '<receiptISODateTime>20230421T113500</receiptISODateTime>',
+      '<zRepNumber>39</zRepNumber>',
+      '<serialNumber>99IEB004001</serialNumber>',
+      '</addInfo>',
+      '</response>',
+    ].join('');
+    const parsed = parseFiscalResponse(xml);
+    expect(parsed.success).toBe(true);
+    expect(parsed.code).toBe('');
+    expect(parsed.status).toBe('2');
+    expect(parsed.addInfo.fiscalReceiptNumber).toBe('5');
+    expect(parsed.addInfo.fiscalReceiptAmount).toBe('13,00');
+    expect(parsed.addInfo.serialNumber).toBe('99IEB004001');
+    expect(parsed.addInfo.zRepNumber).toBe('39');
+  });
+
+  it('parses an error response with code', () => {
+    const xml = '<response success="false" code="PRINTER ERROR" status="0"><addInfo><elementList>lastCommand,printerStatus</elementList><lastCommand>80</lastCommand><printerStatus>00000</printerStatus></addInfo></response>';
+    const parsed = parseFiscalResponse(xml);
+    expect(parsed.success).toBe(false);
+    expect(parsed.code).toBe('PRINTER ERROR');
+    expect(parsed.addInfo.printerStatus).toBe('00000');
+  });
+
+  it('parses a Z report response', () => {
+    const xml = '<response success="true" code="" status="2"><addInfo><elementList>lastCommand,printerStatus,zRepNumber,dailyAmount,serialNumber</elementList><lastCommand>74</lastCommand><printerStatus>20110</printerStatus><zRepNumber>11</zRepNumber><dailyAmount>332,33</dailyAmount><serialNumber>99IEB004001</serialNumber></addInfo></response>';
+    const parsed = parseFiscalResponse(xml);
+    expect(parsed.success).toBe(true);
+    expect(parsed.addInfo.zRepNumber).toBe('11');
+    expect(parsed.addInfo.dailyAmount).toBe('332,33');
+  });
+
+  it('returns empty addInfo when no addInfo block is present', () => {
+    const parsed = parseFiscalResponse('<response success="true" code="" status="2" />');
+    expect(parsed.success).toBe(true);
+    expect(parsed.addInfo).toEqual({});
+  });
+});

--- a/print-server/__tests__/fiscal_receipt.test.js
+++ b/print-server/__tests__/fiscal_receipt.test.js
@@ -24,6 +24,7 @@ const {
   formatAmount,
   formatQuantity,
   paymentTypeFromLabel,
+  toAmountNumber,
   escXml,
 } = require('../formatters/fiscal_receipt.js');
 const {
@@ -85,6 +86,16 @@ describe('formatFiscalReceipt', () => {
       payments: [{ label: 'Contanti', amount: 2 }],
     });
     expect(xml).toContain('department="1"');
+  });
+
+  it('keeps payments whose amount is an Italian comma-decimal string', () => {
+    // Mirrors formatFiscalRefund: "10,00" must not be dropped by the `> 0` filter.
+    const xml = formatFiscalReceipt({
+      orders: [{ items: [{ name: 'Caffè', quantity: 1, unitPrice: 1 }] }],
+      payments: [{ label: 'Contanti', amount: '1,00' }],
+    });
+    expect(xml).toContain('payment="1,00"');
+    expect(xml).toContain('<printRecTotal');
   });
 
   it('escapes XML special characters in item names and payment labels', () => {
@@ -259,6 +270,35 @@ describe('formatFiscalRefund', () => {
   it('throws when no payments are provided', () => {
     expect(() => formatFiscalRefund({ orders: refundJob.orders, payments: [] })).toThrow();
   });
+
+  it('keeps payments whose amount is an Italian comma-decimal string', () => {
+    // String amounts like "10,00" must NOT be filtered out by the `> 0` check:
+    // Number("10,00") is NaN, which previously dropped the payment and made the
+    // job fail with "almeno un pagamento è obbligatorio".
+    const xml = formatFiscalRefund({
+      orders: refundJob.orders,
+      payments: [{ label: 'Contanti', amount: '10,00' }],
+    });
+    expect(xml).toContain('payment="10,00"');
+    expect(xml).toContain('<printRecTotal');
+  });
+});
+
+// ── toAmountNumber (comma-decimal normalization) ──────────────────────────────
+
+describe('toAmountNumber', () => {
+  it('parses Italian comma-decimal strings', () => {
+    expect(toAmountNumber('10,00')).toBe(10);
+    expect(toAmountNumber('0,50')).toBe(0.5);
+  });
+  it('parses plain numbers and dot-decimal strings', () => {
+    expect(toAmountNumber(13)).toBe(13);
+    expect(toAmountNumber('10.00')).toBe(10);
+  });
+  it('returns NaN for non-numeric values', () => {
+    expect(Number.isNaN(toAmountNumber(undefined))).toBe(true);
+    expect(Number.isNaN(toAmountNumber('abc'))).toBe(true);
+  });
 });
 
 // ── formatDuplicateReceipt / formatOpenDrawer / formatRecCash ─────────────────
@@ -413,5 +453,23 @@ describe('parseFiscalResponse', () => {
     const parsed = parseFiscalResponse('<response success="true" code="" status="2" />');
     expect(parsed.success).toBe(true);
     expect(parsed.addInfo).toEqual({});
+  });
+
+  it('reads success/code/status only from the <response> opening tag', () => {
+    // A nested tag carrying attributes with the same names must not be matched.
+    // Previously the regex scanned the whole XML, so a sibling element like
+    // <addInfo success="true" code="X"> would have overridden the real values.
+    const xml = [
+      '<response success="false" code="PRINTER ERROR" status="0">',
+      '<addInfo success="true" code="DIFFERENT" status="9">',
+      '<elementList>x</elementList><x>1</x>',
+      '</addInfo>',
+      '</response>',
+    ].join('');
+    const parsed = parseFiscalResponse(xml);
+    expect(parsed.success).toBe(false);
+    expect(parsed.code).toBe('PRINTER ERROR');
+    expect(parsed.status).toBe('0');
+    expect(parsed.addInfo.x).toBe('1');
   });
 });

--- a/print-server/__tests__/fiscal_receipt.test.js
+++ b/print-server/__tests__/fiscal_receipt.test.js
@@ -12,9 +12,15 @@ const require = createRequire(import.meta.url);
 const {
   buildFiscalXml,
   formatFiscalReceipt,
+  formatFiscalRefund,
+  formatFiscalVoid,
   formatZReport,
   formatXReport,
   formatStatusQuery,
+  formatDuplicateReceipt,
+  formatOpenDrawer,
+  formatRecCash,
+  normalizeRefDate,
   formatAmount,
   formatQuantity,
   paymentTypeFromLabel,
@@ -179,10 +185,112 @@ describe('buildFiscalXml dispatch', () => {
     expect(buildFiscalXml({ printType: 'fiscal_z_report' })).toContain('printZReport');
     expect(buildFiscalXml({ printType: 'fiscal_x_report' })).toContain('printXReport');
     expect(buildFiscalXml({ printType: 'fiscal_status' })).toContain('queryPrinterStatus');
+    expect(buildFiscalXml({ printType: 'fiscal_duplicate' })).toContain('printDuplicateReceipt');
+    expect(buildFiscalXml({ printType: 'fiscal_drawer' })).toContain('openDrawer');
+    expect(buildFiscalXml({ printType: 'fiscal_cash', direction: 'in', amount: 50 })).toContain('printRecCash');
   });
 
   it('throws for unsupported printType', () => {
     expect(() => buildFiscalXml({ printType: 'bogus' })).toThrow(/Tipo fiscale non supportato/);
+  });
+});
+
+// ── formatFiscalVoid (annullo commerciale) ────────────────────────────────────
+
+describe('formatFiscalVoid', () => {
+  const ref = { zRepNumber: '0039', fiscalReceiptNumber: '0005', date: '31/01/2024', serialNumber: '99IEB004001' };
+
+  it('emits a VOID printRecMessage with formatted reference line', () => {
+    const xml = formatFiscalVoid({ receiptRef: ref });
+    expect(xml).toContain('<printerFiscalReceipt>');
+    expect(xml).toContain('message="VOID 0039 0005 31012024 99IEB004001"');
+    expect(xml).toContain('<endFiscalReceipt operator="1" />');
+    expect(xml).toContain('</printerFiscalReceipt>');
+  });
+
+  it('pads reference fields to the required widths', () => {
+    const xml = formatFiscalVoid({ receiptRef: { zRepNumber: '5', fiscalReceiptNumber: '12', date: '01022024', serialNumber: 'XYZ' } });
+    expect(xml).toContain('VOID 0005 0012 01022024 XYZ00000000');
+  });
+
+  it('uses default operator 1 when omitted', () => {
+    const xml = formatFiscalVoid({ receiptRef: ref });
+    expect(xml).toContain('operator="1"');
+  });
+});
+
+describe('normalizeRefDate', () => {
+  it('converts dd/mm/yyyy to ddmmyyyy', () => {
+    expect(normalizeRefDate('31/01/2024')).toBe('31012024');
+    expect(normalizeRefDate('1/2/24')).toBe('01020224');
+  });
+  it('passes through already-compact dates padded to 8 digits', () => {
+    expect(normalizeRefDate('01022024')).toBe('01022024');
+  });
+});
+
+// ── formatFiscalRefund (reso merce) ──────────────────────────────────────────
+
+describe('formatFiscalRefund', () => {
+  const refundJob = {
+    orders: [{ items: [{ name: 'Pasta', quantity: 1, unitPrice: 10, department: 2 }] }],
+    payments: [{ label: 'Contanti', amount: 10 }],
+    totalAmount: 10,
+  };
+
+  it('uses printRecRefund for returned goods', () => {
+    const xml = formatFiscalRefund(refundJob);
+    expect(xml).toContain('<printRecRefund');
+    expect(xml).toContain('description="Pasta"');
+    expect(xml).toContain('unitPrice="10,00"');
+    expect(xml).toContain('department="2"');
+    expect(xml).toContain('<printRecTotal');
+  });
+
+  it('prepends a REFUND reference line when receiptRef is provided', () => {
+    const xml = formatFiscalRefund({ ...refundJob, receiptRef: { zRepNumber: '39', fiscalReceiptNumber: '5', date: '31/01/2024', serialNumber: '99IEB004001' } });
+    expect(xml).toContain('message="REFUND 0039 0005 31012024 99IEB004001"');
+  });
+
+  it('throws when no refund items are provided', () => {
+    expect(() => formatFiscalRefund({ orders: [], payments: [{ label: 'Contanti', amount: 1 }] })).toThrow();
+  });
+
+  it('throws when no payments are provided', () => {
+    expect(() => formatFiscalRefund({ orders: refundJob.orders, payments: [] })).toThrow();
+  });
+});
+
+// ── formatDuplicateReceipt / formatOpenDrawer / formatRecCash ─────────────────
+
+describe('formatDuplicateReceipt', () => {
+  it('emits a printerCommand with printDuplicateReceipt', () => {
+    const xml = formatDuplicateReceipt({});
+    expect(xml).toContain('<printerCommand>');
+    expect(xml).toContain('<printDuplicateReceipt operator="1" />');
+    expect(xml).toContain('</printerCommand>');
+  });
+});
+
+describe('formatOpenDrawer', () => {
+  it('emits a printerCommand with openDrawer', () => {
+    const xml = formatOpenDrawer({ operator: '2' });
+    expect(xml).toContain('<openDrawer operator="2" />');
+  });
+});
+
+describe('formatRecCash', () => {
+  it('builds a cash-in movement with default cash form', () => {
+    const xml = formatRecCash({ direction: 'in', amount: 100 });
+    expect(xml).toContain('<printRecCash operator="1" direction="in" form="cash" amount="100,00" />');
+  });
+  it('builds a cash-out movement with cheque form', () => {
+    const xml = formatRecCash({ direction: 'out', amount: 50, form: 'cheque' });
+    expect(xml).toContain('direction="out" form="cheque" amount="50,00"');
+  });
+  it('defaults direction to in for unknown values', () => {
+    const xml = formatRecCash({ direction: 'sideways', amount: 5 });
+    expect(xml).toContain('direction="in"');
   });
 });
 

--- a/print-server/__tests__/fiscal_receipt.test.js
+++ b/print-server/__tests__/fiscal_receipt.test.js
@@ -222,7 +222,7 @@ describe('formatFiscalVoid', () => {
 describe('normalizeRefDate', () => {
   it('converts dd/mm/yyyy to ddmmyyyy', () => {
     expect(normalizeRefDate('31/01/2024')).toBe('31012024');
-    expect(normalizeRefDate('1/2/24')).toBe('01020224');
+    expect(normalizeRefDate('1/2/24')).toBe('01022024');
   });
   it('passes through already-compact dates padded to 8 digits', () => {
     expect(normalizeRefDate('01022024')).toBe('01022024');

--- a/print-server/__tests__/printer.fpmate.test.js
+++ b/print-server/__tests__/printer.fpmate.test.js
@@ -167,11 +167,13 @@ describe('printFiscal dispatch', () => {
   it('rejects with a clear error when the fpmate host is not configured', async () => {
     // fpmate host is required — no silent 127.0.0.1 fallback. A missing host
     // must fail fast with an explicit message instead of a confusing ECONNREFUSED.
+    // The message stays source-agnostic (no env-var-specific hint) since the host
+    // can come from env vars, printers.config.js, or Directus.
     process.env.PRINTER_0_ID = 'fiscale';
     process.env.PRINTER_0_TYPE = 'fpmate';
     // PRINTER_0_HOST intentionally omitted
     _resetPrinterCache();
-    await expect(printFiscal('<x/>', 'fiscale')).rejects.toThrow(/manca PRINTER_<N>_HOST/);
+    await expect(printFiscal('<x/>', 'fiscale')).rejects.toThrow(/manca l'host della stampante fiscale/);
   });
 
   it('routes an fpmate printer to the fpmate endpoint and parses the response', async () => {

--- a/print-server/__tests__/printer.fpmate.test.js
+++ b/print-server/__tests__/printer.fpmate.test.js
@@ -84,6 +84,15 @@ describe('loadPrintersFromEnv — fpmate type', () => {
     const [p] = loadPrintersFromEnv();
     expect(p.timeout).toBe(30000);
   });
+
+  it('does not silently default host to 127.0.0.1 when missing', () => {
+    // A missing fpmate host must stay unset so the dispatch path rejects clearly,
+    // rather than masking the misconfiguration with a loopback default.
+    withFpmateEnv({});
+    delete process.env.PRINTER_0_HOST;
+    const [p] = loadPrintersFromEnv();
+    expect(p.host).toBeUndefined();
+  });
 });
 
 // ── printFiscal dispatch (local fpmate-like HTTP server) ─────────────────────
@@ -153,6 +162,16 @@ describe('printFiscal dispatch', () => {
     process.env.PRINTER_0_PORT = '9100';
     _resetPrinterCache();
     await expect(printFiscal('<x/>', 'cucina')).rejects.toThrow(/non è di tipo fpmate/);
+  });
+
+  it('rejects with a clear error when the fpmate host is not configured', async () => {
+    // fpmate host is required — no silent 127.0.0.1 fallback. A missing host
+    // must fail fast with an explicit message instead of a confusing ECONNREFUSED.
+    process.env.PRINTER_0_ID = 'fiscale';
+    process.env.PRINTER_0_TYPE = 'fpmate';
+    // PRINTER_0_HOST intentionally omitted
+    _resetPrinterCache();
+    await expect(printFiscal('<x/>', 'fiscale')).rejects.toThrow(/manca PRINTER_<N>_HOST/);
   });
 
   it('routes an fpmate printer to the fpmate endpoint and parses the response', async () => {

--- a/print-server/__tests__/printer.fpmate.test.js
+++ b/print-server/__tests__/printer.fpmate.test.js
@@ -270,3 +270,48 @@ describe('printFiscal dispatch', () => {
     expect(mock.received).toHaveLength(2);
   });
 });
+
+// ── sendFiscalRequest — timeout coercion (C10) ────────────────────────────────
+// La JSDoc di sendFiscalRequest ammette timeout come stringa: un valore non
+// numerico faceva Number(timeout) = NaN e il socket timeout (requestTimeoutMs)
+// diventava NaN. Ora viene coercito a numero finito positivo (fallback 30000).
+
+describe('sendFiscalRequest — timeout coercion', () => {
+  let mock;
+
+  beforeEach(async () => {
+    mock = await startFpmateServer();
+  });
+  afterEach(async () => {
+    if (mock) await mock.close();
+  });
+
+  it('coerces a non-numeric timeout string to the default and still succeeds', async () => {
+    const { sendFiscalRequest } = require('../fpmate-client.js');
+    // timeout non numerico: in precedenza Number('not-a-number') = NaN rendeva
+    // NaN il socket timeout. Ora deve essere coercito a un valore finito.
+    const result = await sendFiscalRequest({
+      xml: '<printerFiscalReceipt/>',
+      host: '127.0.0.1',
+      port: mock.port,
+      timeout: 'not-a-number',
+    });
+    expect(result.success).toBe(true);
+    // L'URL deve contenere un timeout numerico valido (il default 30000),
+    // non la stringa "not-a-number".
+    expect(mock.received).toHaveLength(1);
+    expect(mock.received[0].url).toContain('timeout=30000');
+  });
+
+  it('keeps a valid numeric timeout string in the URL', async () => {
+    const { sendFiscalRequest } = require('../fpmate-client.js');
+    const result = await sendFiscalRequest({
+      xml: '<printerFiscalReceipt/>',
+      host: '127.0.0.1',
+      port: mock.port,
+      timeout: '5000',
+    });
+    expect(result.success).toBe(true);
+    expect(mock.received[0].url).toContain('timeout=5000');
+  });
+});

--- a/print-server/__tests__/printer.fpmate.test.js
+++ b/print-server/__tests__/printer.fpmate.test.js
@@ -1,0 +1,251 @@
+/**
+ * @file __tests__/printer.fpmate.test.js
+ * @description Unit test per il supporto stampanti fiscali fpmate in printer.js:
+ * caricamento config da env, dispatch via printFiscal (con sendFiscalRequest
+ * mockato), validazione tipo stampante e serializzazione coda.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import http from 'http';
+
+const require = createRequire(import.meta.url);
+
+// vitest's vi.mock does not intercept CJS require() via createRequire in this
+// setup, so we exercise printFiscal against a real local HTTP server that
+// mimics fpmate.cgi. This keeps the transport code path real (no module mock)
+// while remaining hermetic and offline.
+
+const printerModule = require('../printer.js');
+const { loadPrintersFromEnv, getPrinterConfig, printFiscal, printViaFpmate, _resetPrinterCache } = printerModule;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function clearAllPrinterEnvVars() {
+  for (const key of Object.keys(process.env)) {
+    if (/^PRINTER_\d+_/.test(key)) delete process.env[key];
+  }
+}
+
+/**
+ * Sets env vars for a single fpmate fiscal printer.
+ */
+function withFpmateEnv(overrides = {}) {
+  const base = {
+    ID: 'fiscale',
+    NAME: 'Stampante Fiscale',
+    TYPE: 'fpmate',
+    HOST: '192.168.1.200',
+    TIMEOUT: '30000',
+    ...overrides,
+  };
+  clearAllPrinterEnvVars();
+  for (const [k, v] of Object.entries(base)) {
+    process.env[`PRINTER_0_${k}`] = v;
+  }
+}
+
+// ── loadPrintersFromEnv ──────────────────────────────────────────────────────
+
+describe('loadPrintersFromEnv — fpmate type', () => {
+  beforeEach(() => { clearAllPrinterEnvVars(); _resetPrinterCache(); });
+  afterEach(() => { clearAllPrinterEnvVars(); _resetPrinterCache(); });
+
+  it('parses a fpmate printer with sensible defaults', () => {
+    withFpmateEnv();
+    const [p] = loadPrintersFromEnv();
+    expect(p.id).toBe('fiscale');
+    expect(p.type).toBe('fpmate');
+    expect(p.host).toBe('192.168.1.200');
+    expect(p.timeout).toBe(30000);
+    expect(p.https).toBe(false);
+    expect(p.username).toBe('');
+    expect(p.password).toBe('');
+    // port defaults to null (→ 80/443)
+    expect(p.port).toBeNull();
+  });
+
+  it('parses https, port and credentials when provided', () => {
+    withFpmateEnv({
+      HTTPS: '1',
+      PORT: '443',
+      USERNAME: 'admin',
+      PASSWORD: 'secret',
+    });
+    const [p] = loadPrintersFromEnv();
+    expect(p.https).toBe(true);
+    expect(p.port).toBe(443);
+    expect(p.username).toBe('admin');
+    expect(p.password).toBe('secret');
+  });
+
+  it('falls back to default timeout for invalid timeout value', () => {
+    withFpmateEnv({ TIMEOUT: 'not-a-number' });
+    const [p] = loadPrintersFromEnv();
+    expect(p.timeout).toBe(30000);
+  });
+});
+
+// ── printFiscal dispatch (local fpmate-like HTTP server) ─────────────────────
+
+/**
+ * Starts a local HTTP server mimicking fpmate.cgi. Returns the server and a
+ * function to set the response body (and status) for the next request.
+ */
+function startFpmateServer() {
+  let nextResponse = '<response success="true" code="" status="2"><addInfo><elementList>lastCommand,printerStatus,fiscalReceiptNumber</elementList><lastCommand>74</lastCommand><printerStatus>20010</printerStatus><fiscalReceiptNumber>1</fiscalReceiptNumber></addInfo></response>';
+  let nextStatus = 200;
+  const received = [];
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      received.push({
+        method: req.method,
+        url: req.url,
+        body: Buffer.concat(chunks).toString('utf8'),
+        contentType: req.headers['content-type'],
+        ifModifiedSince: req.headers['if-modified-since'],
+      });
+      res.writeHead(nextStatus, { 'Content-Type': 'text/xml; charset=utf-8', 'Access-Control-Allow-Origin': '*' });
+      res.end(nextResponse);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        server,
+        port,
+        received,
+        setResponse: (body, status = 200) => { nextResponse = body; nextStatus = status; },
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe('printFiscal dispatch', () => {
+  let mock;
+
+  beforeEach(async () => {
+    clearAllPrinterEnvVars();
+    _resetPrinterCache();
+    mock = await startFpmateServer();
+  });
+
+  afterEach(async () => {
+    clearAllPrinterEnvVars();
+    _resetPrinterCache();
+    if (mock) await mock.close();
+  });
+
+  it('rejects when no printers are configured', async () => {
+    clearAllPrinterEnvVars();
+    _resetPrinterCache();
+    await expect(printFiscal('<x/>', 'fiscale')).rejects.toThrow(/No printers configured/);
+  });
+
+  it('rejects when the resolved printer is not fpmate type', async () => {
+    process.env.PRINTER_0_ID = 'cucina';
+    process.env.PRINTER_0_TYPE = 'tcp';
+    process.env.PRINTER_0_HOST = '127.0.0.1';
+    process.env.PRINTER_0_PORT = '9100';
+    _resetPrinterCache();
+    await expect(printFiscal('<x/>', 'cucina')).rejects.toThrow(/non è di tipo fpmate/);
+  });
+
+  it('routes an fpmate printer to the fpmate endpoint and parses the response', async () => {
+    process.env.PRINTER_0_ID = 'fiscale';
+    process.env.PRINTER_0_TYPE = 'fpmate';
+    process.env.PRINTER_0_HOST = '127.0.0.1';
+    process.env.PRINTER_0_PORT = String(mock.port);
+    process.env.PRINTER_0_TIMEOUT = '5000';
+    _resetPrinterCache();
+
+    mock.setResponse(
+      '<response success="true" code="" status="2"><addInfo><elementList>lastCommand,printerStatus,fiscalReceiptNumber,fiscalReceiptAmount,serialNumber</elementList><lastCommand>74</lastCommand><printerStatus>20010</printerStatus><fiscalReceiptNumber>5</fiscalReceiptNumber><fiscalReceiptAmount>13,00</fiscalReceiptAmount><serialNumber>99IEB004001</serialNumber></addInfo></response>'
+    );
+
+    const result = await printFiscal('<printerFiscalReceipt/>', 'fiscale');
+    expect(result.success).toBe(true);
+    expect(result.addInfo.fiscalReceiptNumber).toBe('5');
+    expect(result.addInfo.serialNumber).toBe('99IEB004001');
+
+    // Verify the HTTP request shape against the fpmate.cgi spec.
+    expect(mock.received).toHaveLength(1);
+    const req = mock.received[0];
+    expect(req.method).toBe('POST');
+    expect(req.url).toContain('/cgi-bin/fpmate.cgi');
+    expect(req.url).toContain('timeout=5000');
+    expect(req.contentType).toBe('text/xml; charset=utf-8');
+    expect(req.body).toContain('<s:Envelope');
+    expect(req.body).toContain('<s:Body>');
+    expect(req.body).toContain('<printerFiscalReceipt/>');
+    expect(req.ifModifiedSince).toBe('Thu, 01 Jan 1970 00:00:00 GMT');
+  });
+
+  it('rejects on HTTP error status', async () => {
+    process.env.PRINTER_0_ID = 'fiscale';
+    process.env.PRINTER_0_TYPE = 'fpmate';
+    process.env.PRINTER_0_HOST = '127.0.0.1';
+    process.env.PRINTER_0_PORT = String(mock.port);
+    _resetPrinterCache();
+    mock.setResponse('boom', 500);
+    await expect(printFiscal('<x/>', 'fiscale')).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('serializes concurrent fiscal jobs for the same printer', async () => {
+    process.env.PRINTER_0_ID = 'fiscale';
+    process.env.PRINTER_0_TYPE = 'fpmate';
+    process.env.PRINTER_0_HOST = '127.0.0.1';
+    process.env.PRINTER_0_PORT = String(mock.port);
+    _resetPrinterCache();
+
+    // First request stalls until we release it; second must wait.
+    const waitFor = (pred) => new Promise((resolve) => {
+      const tick = () => { if (pred()) resolve(); else setImmediate(tick); };
+      tick();
+    });
+    let firstResReady;
+    const firstResponsePromise = new Promise((r) => { firstResReady = r; });
+    let completeFirst;
+    const firstCompletion = new Promise((r) => { completeFirst = r; });
+    mock.server.removeAllListeners('request');
+    let firstHandlerPending = false;
+    mock.server.on('request', (req, res) => {
+      const chunks = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        mock.received.push({ method: req.method, url: req.url, body: Buffer.concat(chunks).toString('utf8') });
+        if (!firstHandlerPending) {
+          firstHandlerPending = true;
+          firstResReady();
+          // Respond only once the test releases the first job.
+          firstCompletion.then(() => {
+            res.writeHead(200, { 'Content-Type': 'text/xml; charset=utf-8' });
+            res.end('<response success="true" code="" status="2"><addInfo><elementList>lastCommand</elementList><lastCommand>74</lastCommand></addInfo></response>');
+          });
+        } else {
+          res.writeHead(200, { 'Content-Type': 'text/xml; charset=utf-8' });
+          res.end('<response success="true" code="" status="2"><addInfo><elementList>lastCommand</elementList><lastCommand>74</lastCommand></addInfo></response>');
+        }
+      });
+    });
+
+    const p1 = printFiscal('<a/>', 'fiscale');
+    await firstResponsePromise;
+    await waitFor(() => mock.received.length === 1);
+    expect(mock.received).toHaveLength(1);
+    const p2 = printFiscal('<b/>', 'fiscale');
+    // Give the second job a chance to (incorrectly) dispatch — it must not.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mock.received).toHaveLength(1);
+
+    completeFirst();
+    await p1;
+    await p2;
+    await waitFor(() => mock.received.length === 2);
+    expect(mock.received).toHaveLength(2);
+  });
+});

--- a/print-server/__tests__/printer.test.js
+++ b/print-server/__tests__/printer.test.js
@@ -4,11 +4,11 @@
  * I test di serializzazione della coda sono in printer.queue.test.js.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const { findPrinterConfig, getPrintersList, printBuffer } = require('../printer.js');
+const { findPrinterConfig, getPrintersList, printBuffer, setPrinters, _resetPrinterCache } = require('../printer.js');
 
 // ── Test printer fixtures ─────────────────────────────────────────────────────
 
@@ -74,6 +74,39 @@ describe('printBuffer — no printers configured', () => {
     // Default printers.config.js has no entries; printBuffer should reject
     const buf = Buffer.from([0x1b, 0x40]);
     await expect(printBuffer(buf, 'cucina')).rejects.toThrow('No printers configured');
+  });
+});
+
+// ── printBuffer — rejects fpmate printers ─────────────────────────────────────
+// printBuffer riceve byte ESC/POS; una stampante fpmate accetta solo XML
+// fiscale via SOAP. Inviare ESC/POS a fpmate produrrebbe XML/SOAP non valido:
+// printBuffer deve rifiutare esplicitamente le stampanti fpmate e indirizzare i
+// chiamanti a printFiscal().
+
+describe('printBuffer — rejects fpmate printers', () => {
+  afterEach(() => { setPrinters([]); _resetPrinterCache(); });
+
+  it('rejects a fpmate printer with a message pointing to printFiscal()', async () => {
+    setPrinters([{ id: 'fiscale', name: 'Epson RT', type: 'fpmate', host: 'http://printer.local' }]);
+    const buf = Buffer.from([0x1b, 0x40]);
+    await expect(printBuffer(buf, 'fiscale')).rejects.toThrow(/fpmate.*printFiscal/);
+  });
+
+  it('also rejects when printerId falls back to a fpmate printer (unknown id)', async () => {
+    // findPrinterConfig falls back to the first printer when printerId is
+    // missing/unknown: if that first printer is fpmate, printBuffer must still
+    // reject rather than send ESC/POS to the fiscal endpoint.
+    setPrinters([{ id: 'fiscale', name: 'Epson RT', type: 'fpmate', host: 'http://printer.local' }]);
+    const buf = Buffer.from([0x1b, 0x40]);
+    await expect(printBuffer(buf, 'unknown-printer')).rejects.toThrow(/fpmate.*printFiscal/);
+  });
+
+  it('still accepts ESC/POS for a file printer', async () => {
+    // Sanity check: the fpmate guard must not break legitimate ESC/POS printers.
+    // Use a file printer to avoid real network I/O.
+    setPrinters([{ id: 'cassa', name: 'Cassa', type: 'file', device: '/dev/null' }]);
+    const buf = Buffer.from([0x1b, 0x40]);
+    await expect(printBuffer(buf, 'cassa')).resolves.toBeUndefined();
   });
 });
 

--- a/print-server/__tests__/printer.test.js
+++ b/print-server/__tests__/printer.test.js
@@ -4,7 +4,7 @@
  * I test di serializzazione della coda sono in printer.queue.test.js.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);

--- a/print-server/__tests__/server.fiscal.test.js
+++ b/print-server/__tests__/server.fiscal.test.js
@@ -1,0 +1,43 @@
+/**
+ * @file __tests__/server.fiscal.test.js
+ * @description Test isolato per la composizione del messaggio di errore quando
+ * la stampante fiscale risponde HTTP 200 ma con success=false (fallimento a
+ * livello applicativo). Il server ora espone `buildFiscalErrorMessage`, che
+ * ricava un errore leggibile dal code/status fpmate invece di un generico
+ * "HTTP 200" senza motivo.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { buildFiscalErrorMessage } = require('../server.js');
+
+describe('buildFiscalErrorMessage (fiscal application-level failure)', () => {
+  it('builds the message from the fpmate code', () => {
+    expect(buildFiscalErrorMessage({ code: 'PRINTER ERROR', status: '0' })).toBe(
+      'Errore stampante fiscale: PRINTER ERROR'
+    );
+  });
+
+  it('falls back to status when code is empty/blank', () => {
+    expect(buildFiscalErrorMessage({ code: '   ', status: '3' })).toBe(
+      'Errore stampante fiscale: status 3'
+    );
+  });
+
+  it('returns a generic message when neither code nor status is present', () => {
+    expect(buildFiscalErrorMessage({ code: '', status: '' })).toBe(
+      'Errore stampante fiscale.'
+    );
+    expect(buildFiscalErrorMessage({})).toBe('Errore stampante fiscale.');
+    expect(buildFiscalErrorMessage(null)).toBe('Errore stampante fiscale.');
+  });
+
+  it('ignores non-string code/status values', () => {
+    expect(buildFiscalErrorMessage({ code: 5, status: 2 })).toBe(
+      'Errore stampante fiscale.'
+    );
+  });
+});
+

--- a/print-server/__tests__/server.printers.test.js
+++ b/print-server/__tests__/server.printers.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * @file __tests__/server.printers.test.js
+ * @description Unit test per GET /printers: verifica che i dettagli di rete
+ * (host/port/device) vengano redatti quando PRINT_SERVER_API_KEY non è
+ * configurata (CORS aperto di default), ed esposti solo quando l'endpoint è
+ * protetto da API key.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+// Importa server.js come modulo: con require.main !== module il server non
+// si mette in ascolto, e possiamo testare la pure helper buildPrinterSummary.
+const { buildPrinterSummary } = require('../server.js');
+
+describe('buildPrinterSummary — GET /printers network-detail redaction', () => {
+  it('omits host/port/device when not authenticated (no API key)', () => {
+    const tcp = buildPrinterSummary(
+      { id: 'cucina', name: 'Cucina', type: 'tcp', host: '192.168.1.50', port: 9100 },
+      false
+    );
+    expect(tcp).toEqual({ id: 'cucina', name: 'Cucina', type: 'tcp' });
+    expect(tcp).not.toHaveProperty('host');
+    expect(tcp).not.toHaveProperty('port');
+  });
+
+  it('omits device for file printers when not authenticated', () => {
+    const file = buildPrinterSummary(
+      { id: 'lp0', name: 'USB', type: 'file', device: '/dev/usb/lp0' },
+      false
+    );
+    expect(file).toEqual({ id: 'lp0', name: 'USB', type: 'file' });
+    expect(file).not.toHaveProperty('device');
+  });
+
+  it('omits host/port/https for fpmate printers when not authenticated', () => {
+    const fpmate = buildPrinterSummary(
+      { id: 'fiscale', name: 'Epson RT', type: 'fpmate', host: '192.168.1.200', port: 443, https: true },
+      false
+    );
+    expect(fpmate).toEqual({ id: 'fiscale', name: 'Epson RT', type: 'fpmate' });
+    expect(fpmate).not.toHaveProperty('host');
+  });
+
+  it('exposes host/port for tcp printers when authenticated (API key set)', () => {
+    const tcp = buildPrinterSummary(
+      { id: 'cucina', name: 'Cucina', type: 'tcp', host: '192.168.1.50', port: 9100 },
+      true
+    );
+    expect(tcp.host).toBe('192.168.1.50');
+    expect(tcp.port).toBe(9100);
+  });
+
+  it('exposes host/port/https for fpmate printers when authenticated', () => {
+    const fpmate = buildPrinterSummary(
+      { id: 'fiscale', name: 'Epson RT', type: 'fpmate', host: '192.168.1.200', port: 443, https: true },
+      true
+    );
+    expect(fpmate.host).toBe('192.168.1.200');
+    expect(fpmate.port).toBe(443);
+    expect(fpmate.https).toBe(true);
+  });
+
+  it('defaults fpmate port to null when authenticated and port unset', () => {
+    const fpmate = buildPrinterSummary(
+      { id: 'fiscale', name: 'Epson RT', type: 'fpmate', host: '192.168.1.200', https: false },
+      true
+    );
+    expect(fpmate.port).toBeNull();
+    expect(fpmate.https).toBe(false);
+  });
+});

--- a/print-server/formatters/fiscal_receipt.js
+++ b/print-server/formatters/fiscal_receipt.js
@@ -309,11 +309,29 @@ function formatFiscalRefund(job) {
 
   const lines = ['<printerFiscalReceipt>'];
 
-  if (ref && (ref.zRepNumber || ref.fiscalReceiptNumber)) {
-    const z = String(ref.zRepNumber ?? '0000').padStart(4, '0');
-    const n = String(ref.fiscalReceiptNumber ?? '0000').padStart(4, '0');
+  if (ref) {
+    // La riga REFUND zzzz nnnn ddmmyyyy sssssssssss è valida solo se TUTTI i
+    // campi del riferimento sono presenti e non vuoti: se ne manca qualcuno la
+    // stampante fiscale può rifiutare il comando o collegare il reso al documento
+    // sbagliato. Verifica quindi la completezza prima di emettere la riga.
+    const zRaw = String(ref.zRepNumber ?? '').trim();
+    const nRaw = String(ref.fiscalReceiptNumber ?? '').trim();
     const d = normalizeRefDate(ref.date);
-    const s = String(ref.serialNumber ?? '').padStart(11, '0').slice(0, 11);
+    const sRaw = String(ref.serialNumber ?? '').trim();
+    const missing = [];
+    if (!zRaw) missing.push('zRepNumber');
+    if (!nRaw) missing.push('fiscalReceiptNumber');
+    if (!/^\d{8}$/.test(d)) missing.push('date');
+    if (!sRaw) missing.push('serialNumber');
+    if (missing.length) {
+      throw new Error(
+        `fiscal_refund: receiptRef incompleto (campi mancanti o non validi: ${missing.join(', ')}); `
+        + 'omettere receiptRef per un reso senza riferimento oppure fornire tutti i campi'
+      );
+    }
+    const z = zRaw.padStart(4, '0');
+    const n = nRaw.padStart(4, '0');
+    const s = sRaw.padStart(11, '0').slice(0, 11);
     lines.push(
       `<printRecMessage operator="${escXml(operator)}" messageType="4" message="${escXml(`REFUND ${z} ${n} ${d} ${s}`)}" />`
     );

--- a/print-server/formatters/fiscal_receipt.js
+++ b/print-server/formatters/fiscal_receipt.js
@@ -12,9 +12,14 @@
  *
  * Job supportati:
  *   - fiscal_receipt   → documento commerciale (scontrino fiscale)
+ *   - fiscal_refund    → documento di reso commerciale (RESO MERCE)
+ *   - fiscal_void      → documento di annullo commerciale (VOID)
  *   - fiscal_z_report  → chiusura giornaliera (Z report)
  *   - fiscal_x_report  → report finanziario giornaliero (X report)
  *   - fiscal_status    → query stato stampante (base o RT)
+ *   - fiscal_duplicate → ristampa ultimo scontrino (documento di gestione)
+ *   - fiscal_drawer    → apertura cassetto contanti
+ *   - fiscal_cash      → versamento/prelievo cassa fiscale (cash in/out)
  */
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -194,6 +199,194 @@ function formatXReport(job) {
   ].join('\n');
 }
 
+// ── Void document (annullo commerciale) ──────────────────────────────────────
+
+/**
+ * Formatta la data del documento di riferimento nel formato dd/mm/yyyy → ddmmyyyy.
+ * Accetta "dd/mm/yyyy", "dd-mm-yyyy" o già "ddmmyyyy".
+ * @param {string} date
+ * @returns {string}
+ */
+function normalizeRefDate(date) {
+  const s = String(date ?? '').trim();
+  const m = s.match(/^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{2,4})$/);
+  if (m) {
+    const dd = m[1].padStart(2, '0');
+    const mm = m[2].padStart(2, '0');
+    const yy = m[3].length === 2 ? m[3] : m[3].slice(-2);
+    return `${dd}${mm}${yy}`;
+  }
+  // Già in formato ddmmyyyy (4-8 cifre): normalizza a 8 cifre con padding.
+  if (/^\d{4,8}$/.test(s)) return s.padStart(8, '0');
+  return s;
+}
+
+/**
+ * Costruisce l'XML per un documento di annullo commerciale (VOID).
+ * Richiede i riferimenti dello scontrino da annullare (zRepNumber, fiscalReceiptNumber,
+ * date, serialNumber) recuperabili dalla risposta fpmate originaria salvata in fiscal_receipts.
+ *
+ * La riga "VOID zzzz nnnn ddmmyyyy sssssssssss" va emessa come printRecMessage
+ * messageType=4 PRIMA di endFiscalReceipt (beginFiscalReceipt non è richiesto per i
+ * documenti di annullo automatici, ma viene comunque incluso per conformità).
+ *
+ * Payload atteso (job):
+ * {
+ *   printType: 'fiscal_void',
+ *   operator?: string|number,
+ *   receiptRef: {
+ *     zRepNumber: string,            // numero Z a 4 cifre
+ *     fiscalReceiptNumber: string,   // numero scontrino a 4 cifre
+ *     date: string,                  // "dd/mm/yyyy" o "ddmmyyyy"
+ *     serialNumber: string,          // matricola RT a 11 caratteri
+ *   }
+ * }
+ * @param {object} job
+ * @returns {string}
+ */
+function formatFiscalVoid(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  const ref = job.receiptRef ?? {};
+  const z = String(ref.zRepNumber ?? '0000').padStart(4, '0');
+  const n = String(ref.fiscalReceiptNumber ?? '0000').padStart(4, '0');
+  const d = normalizeRefDate(ref.date);
+  const s = String(ref.serialNumber ?? '').padEnd(11, '0').slice(0, 11);
+  const voidLine = `VOID ${z} ${n} ${d} ${s}`;
+  return [
+    '<printerFiscalReceipt>',
+    `<printRecMessage operator="${escXml(operator)}" messageType="4" message="${escXml(voidLine)}" />`,
+    `<endFiscalReceipt operator="${escXml(operator)}" />`,
+    '</printerFiscalReceipt>',
+  ].join('\n');
+}
+
+// ── Refund document (reso merce) ─────────────────────────────────────────────
+
+/**
+ * Costruisce l'XML per un documento di reso commerciale (REFUND / "RESO MERCE").
+ * Se fornito receiptRef, apre con la riga "REFUND zzzz nnnn ddmmyyyy sssssssssss";
+ * altrimenti emette un reso senza riferimento (reso generico della giornata).
+ * Le voci usano printRecRefund (importi positivi che la stampante segna come negativi);
+ * il totale usa paymentType=0 (contanti) con importo = totale reso (restituito al cliente).
+ *
+ * Payload atteso (job):
+ * {
+ *   printType: 'fiscal_refund',
+ *   operator?: string|number,
+ *   receiptRef?: { zRepNumber, fiscalReceiptNumber, date, serialNumber },
+ *   orders: [{ items: [{ name, quantity, unitPrice, department? }] }],
+ *   payments: [{ label, amount }],
+ *   totalAmount: number,
+ * }
+ * @param {object} job
+ * @returns {string}
+ */
+function formatFiscalRefund(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  const orders = Array.isArray(job.orders) ? job.orders : [];
+  const items = orders.flatMap((o) => Array.isArray(o?.items) ? o.items : []);
+  const payments = Array.isArray(job.payments) ? job.payments.filter((p) => p && Number(p.amount) > 0) : [];
+  const ref = job.receiptRef ?? null;
+
+  if (items.length === 0) throw new Error('fiscal_refund: almeno una voce di reso è obbligatoria');
+  if (payments.length === 0) throw new Error('fiscal_refund: almeno un pagamento è obbligatorio');
+
+  const lines = ['<printerFiscalReceipt>'];
+
+  if (ref && (ref.zRepNumber || ref.fiscalReceiptNumber)) {
+    const z = String(ref.zRepNumber ?? '0000').padStart(4, '0');
+    const n = String(ref.fiscalReceiptNumber ?? '0000').padStart(4, '0');
+    const d = normalizeRefDate(ref.date);
+    const s = String(ref.serialNumber ?? '').padStart(11, '0').slice(0, 11);
+    lines.push(
+      `<printRecMessage operator="${escXml(operator)}" messageType="4" message="${escXml(`REFUND ${z} ${n} ${d} ${s}`)}" />`
+    );
+  }
+
+  lines.push(`<beginFiscalReceipt operator="${escXml(operator)}" />`);
+
+  for (const item of items) {
+    const name = item.name ?? '';
+    const qty = formatQuantity(item.quantity ?? 1);
+    const price = formatAmount(item.unitPrice ?? 0);
+    const department = Number(item.department) > 0 ? Number(item.department) : 1;
+    lines.push(
+      `<printRecRefund operator="${escXml(operator)}" description="${escXml(name)}" quantity="${qty}" unitPrice="${price}" department="${department}" justification="1" />`
+    );
+  }
+
+  for (const payment of payments) {
+    const pType = paymentTypeFromLabel(payment.label ?? '');
+    const amount = formatAmount(payment.amount);
+    lines.push(
+      `<printRecTotal operator="${escXml(operator)}" description="${escXml(payment.label ?? 'CONTANTI')}" payment="${amount}" paymentType="${pType}" justification="2" />`
+    );
+  }
+
+  lines.push(`<endFiscalReceipt operator="${escXml(operator)}" />`);
+  lines.push('</printerFiscalReceipt>');
+  return lines.join('\n');
+}
+
+// ── Duplicate receipt / drawer / cash (printerCommand) ───────────────────────
+
+/**
+ * Costruisce l'XML per la ristampa dell'ultimo scontrino commerciale (duplicato).
+ * Emesso come documento di gestione (non fiscale): la legge vieta di ristampare
+ * l'originale nello stesso formato, quindi viene letto dall'MPD (EJ).
+ * @param {object} job
+ * @returns {string}
+ */
+function formatDuplicateReceipt(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  return [
+    '<printerCommand>',
+    `<printDuplicateReceipt operator="${escXml(operator)}" />`,
+    '</printerCommand>',
+  ].join('\n');
+}
+
+/**
+ * Costruisce l'XML per l'apertura del cassetto contanti collegato alla stampante.
+ * @param {object} job
+ * @returns {string}
+ */
+function formatOpenDrawer(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  return [
+    '<printerCommand>',
+    `<openDrawer operator="${escXml(operator)}" />`,
+    '</printerCommand>',
+  ].join('\n');
+}
+
+/**
+ * Costruisce l'XML per un movimento di cassa fiscale (versamento/prelievo contanti
+ * o assegni). Registra il movimento nella memoria fiscale della stampante RT.
+ *
+ * Payload atteso (job):
+ * {
+ *   printType: 'fiscal_cash',
+ *   operator?: string|number,
+ *   direction: 'in' | 'out',   // 'in' = versamento, 'out' = prelievo
+ *   amount: number,             // importo > 0
+ *   form?: 'cash' | 'cheque',   // default 'cash'
+ * }
+ * @param {object} job
+ * @returns {string}
+ */
+function formatRecCash(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  const direction = job.direction === 'out' ? 'out' : 'in';
+  const form = job.form === 'cheque' || job.form === 'check' ? 'cheque' : 'cash';
+  const amount = formatAmount(job.amount ?? 0);
+  return [
+    '<printerCommand>',
+    `<printRecCash operator="${escXml(operator)}" direction="${direction}" form="${form}" amount="${amount}" />`,
+    '</printerCommand>',
+  ].join('\n');
+}
+
 // ── Printer status query ─────────────────────────────────────────────────────
 
 /**
@@ -223,9 +416,14 @@ function formatStatusQuery(job) {
 function buildFiscalXml(job) {
   switch (job.printType) {
     case 'fiscal_receipt':  return formatFiscalReceipt(job);
+    case 'fiscal_refund':   return formatFiscalRefund(job);
+    case 'fiscal_void':     return formatFiscalVoid(job);
     case 'fiscal_z_report': return formatZReport(job);
     case 'fiscal_x_report': return formatXReport(job);
     case 'fiscal_status':   return formatStatusQuery(job);
+    case 'fiscal_duplicate':return formatDuplicateReceipt(job);
+    case 'fiscal_drawer':   return formatOpenDrawer(job);
+    case 'fiscal_cash':     return formatRecCash(job);
     default: {
       const err = new Error(`Tipo fiscale non supportato: ${job.printType}`);
       err.permanent = true;
@@ -237,11 +435,17 @@ function buildFiscalXml(job) {
 module.exports = {
   buildFiscalXml,
   formatFiscalReceipt,
+  formatFiscalRefund,
+  formatFiscalVoid,
   formatZReport,
   formatXReport,
   formatStatusQuery,
+  formatDuplicateReceipt,
+  formatOpenDrawer,
+  formatRecCash,
   escXml,
   formatAmount,
   formatQuantity,
+  normalizeRefDate,
   paymentTypeFromLabel,
 };

--- a/print-server/formatters/fiscal_receipt.js
+++ b/print-server/formatters/fiscal_receipt.js
@@ -202,8 +202,9 @@ function formatXReport(job) {
 // ── Void document (annullo commerciale) ──────────────────────────────────────
 
 /**
- * Formatta la data del documento di riferimento nel formato dd/mm/yyyy → ddmmyyyy.
- * Accetta "dd/mm/yyyy", "dd-mm-yyyy" o già "ddmmyyyy".
+ * Formatta la data del documento di riferimento nel formato dd/mm/yyyy → ddmmyyyy
+ * (8 cifre, anno a 4 cifre come richiesto dalla stampante RT). Accetta "dd/mm/yyyy",
+ * "dd-mm-yyyy" o già "ddmmyyyy". Gli anni a 2 cifre vengono espansi con pivot 2000.
  * @param {string} date
  * @returns {string}
  */
@@ -213,7 +214,7 @@ function normalizeRefDate(date) {
   if (m) {
     const dd = m[1].padStart(2, '0');
     const mm = m[2].padStart(2, '0');
-    const yy = m[3].length === 2 ? m[3] : m[3].slice(-2);
+    const yy = m[3].length === 2 ? String(2000 + Number(m[3])) : m[3].padStart(4, '0');
     return `${dd}${mm}${yy}`;
   }
   // Già in formato ddmmyyyy (4-8 cifre): normalizza a 8 cifre con padding.
@@ -227,8 +228,9 @@ function normalizeRefDate(date) {
  * date, serialNumber) recuperabili dalla risposta fpmate originaria salvata in fiscal_receipts.
  *
  * La riga "VOID zzzz nnnn ddmmyyyy sssssssssss" va emessa come printRecMessage
- * messageType=4 PRIMA di endFiscalReceipt (beginFiscalReceipt non è richiesto per i
- * documenti di annullo automatici, ma viene comunque incluso per conformità).
+ * messageType=4 PRIMA di endFiscalReceipt. Per i documenti di annullo
+ * automatici la stampante RT non richiede beginFiscalReceipt, quindi non viene
+ * emesso (la riga VOID apre direttamente il documento di annullo).
  *
  * Payload atteso (job):
  * {

--- a/print-server/formatters/fiscal_receipt.js
+++ b/print-server/formatters/fiscal_receipt.js
@@ -1,0 +1,247 @@
+'use strict';
+
+/**
+ * @file formatters/fiscal_receipt.js
+ * @description Costruisce i payload XML (Fiscal ePOS-Print) per la stampante
+ * fiscale Epson RT, secondo l'"ePOS Fiscal Print Solution Development Guide".
+ *
+ * Il protocollo fpmate.cgi è SOAP/HTTP: l'XML qui prodotto va incapsulato in una
+ * busta SOAP dal transport (fpmate-client.js) prima dell'invio.
+ *
+ * Output: stringa XML (senza envelope SOAP), pronta per `sendFiscalRequest()`.
+ *
+ * Job supportati:
+ *   - fiscal_receipt   → documento commerciale (scontrino fiscale)
+ *   - fiscal_z_report  → chiusura giornaliera (Z report)
+ *   - fiscal_x_report  → report finanziario giornaliero (X report)
+ *   - fiscal_status    → query stato stampante (base o RT)
+ */
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Escape dei caratteri speciali XML in un valore attributo.
+ * @param {*} v
+ * @returns {string}
+ */
+function escXml(v) {
+  return String(v).replace(/[<>&"']/g, (c) => (
+    { '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&apos;' }[c]
+  ));
+}
+
+/**
+ * Formatta un importo numerico con due decimali usando la virgola come
+ * separatore decimale (convenzione italiana richiesta dalla stampante).
+ * Accetta anche stringhe già formattate, normalizzando il separatore.
+ * @param {number|string} value
+ * @returns {string}
+ */
+function formatAmount(value) {
+  if (typeof value === 'string' && value.trim() !== '') {
+    // Normalizza eventuali punti decimali in virgola (la stampante accetta entrambi,
+    // ma usiamo la virgola per coerenza con le risposte).
+    return value.replace(/\./g, ',');
+  }
+  const n = Number(value);
+  if (!Number.isFinite(n)) return '0,00';
+  return n.toFixed(2).replace('.', ',');
+}
+
+/**
+ * Formatta una quantità con tre decimali (range 0.001–9999.999).
+ * @param {number|string} value
+ * @returns {string}
+ */
+function formatQuantity(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return '1,000';
+  return n.toFixed(3).replace('.', ',');
+}
+
+/**
+ * Determina il paymentType fpmate a partire dall'etichetta del metodo di pagamento.
+ *   0 = Contanti
+ *   2 = Elettronico (carta/bancomat/pos)
+ * Gli altri tipi (1 assegno, 3 ticket, 5 non pagato) non sono usati dal flusso cassa.
+ * @param {string} label
+ * @returns {string}
+ */
+function paymentTypeFromLabel(label) {
+  if (/cart|bancomat|pos|visa|master|carta|credit|electron|maestro/i.test(label)) {
+    return '2';
+  }
+  return '0';
+}
+
+// ── Fiscal receipt (commercial document) ─────────────────────────────────────
+
+/**
+ * Costruisce l'XML per un documento commerciale (scontrino fiscale).
+ *
+ * Payload atteso (job):
+ * {
+ *   printType: 'fiscal_receipt',
+ *   operator?: string|number,        // default '1' (range 1–12)
+ *   cashier?: string,                // etichetta cassiere (opzionale, solo log)
+ *   orders: [
+ *     {
+ *       items: [
+ *         { name: string, quantity: number, unitPrice: number, department?: number }
+ *       ]
+ *     }
+ *   ],
+ *   payments: [
+ *     { label: string, amount: number }   // più pagamenti parziali supportati
+ *   ],
+ *   totalAmount: number,             // totale lordo (per controllo)
+ *   headerLines?: string[],          // righe intestazione aggiuntive (messageType 1)
+ *   trailerLines?: string[],         // righe trailer (messageType 3)
+ * }
+ *
+ * @param {object} job
+ * @returns {string} XML string (printerFiscalReceipt root)
+ */
+function formatFiscalReceipt(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  const orders = Array.isArray(job.orders) ? job.orders : [];
+  const items = orders.flatMap((o) => Array.isArray(o?.items) ? o.items : []);
+  const payments = Array.isArray(job.payments) ? job.payments.filter((p) => p && Number(p.amount) > 0) : [];
+
+  if (items.length === 0) {
+    throw new Error('fiscal_receipt: almeno una voce di vendita è obbligatoria');
+  }
+  if (payments.length === 0) {
+    throw new Error('fiscal_receipt: almeno un pagamento è obbligatorio');
+  }
+
+  const lines = ['<printerFiscalReceipt>'];
+
+  // Righe intestazione aggiuntive (devono precedere beginFiscalReceipt)
+  const headerLines = Array.isArray(job.headerLines) ? job.headerLines : [];
+  headerLines.forEach((line, i) => {
+    lines.push(
+      `<printRecMessage operator="${escXml(operator)}" messageType="1" index="${i + 1}" font="1" message="${escXml(line)}" />`
+    );
+  });
+
+  lines.push(`<beginFiscalReceipt operator="${escXml(operator)}" />`);
+
+  // Voci di vendita
+  for (const item of items) {
+    const name = item.name ?? '';
+    const qty = formatQuantity(item.quantity ?? 1);
+    const price = formatAmount(item.unitPrice ?? 0);
+    const department = Number(item.department) > 0 ? Number(item.department) : 1;
+    lines.push(
+      `<printRecItem operator="${escXml(operator)}" description="${escXml(name)}" quantity="${qty}" unitPrice="${price}" department="${department}" justification="1" />`
+    );
+  }
+
+  // Trailer aggiuntivi (messageType 3, dopo le voci)
+  const trailerLines = Array.isArray(job.trailerLines) ? job.trailerLines : [];
+  trailerLines.forEach((line, i) => {
+    lines.push(
+      `<printRecMessage operator="${escXml(operator)}" messageType="3" index="${i + 1}" font="1" message="${escXml(line)}" />`
+    );
+  });
+
+  // Pagamenti (uno o più printRecTotal)
+  for (const payment of payments) {
+    const pType = paymentTypeFromLabel(payment.label ?? '');
+    const amount = formatAmount(payment.amount);
+    const description = escXml(payment.label ?? 'CONTANTI');
+    lines.push(
+      `<printRecTotal operator="${escXml(operator)}" description="${description}" payment="${amount}" paymentType="${pType}" justification="2" />`
+    );
+  }
+
+  lines.push(`<endFiscalReceipt operator="${escXml(operator)}" />`);
+  lines.push('</printerFiscalReceipt>');
+
+  return lines.join('\n');
+}
+
+// ── Z / X reports ────────────────────────────────────────────────────────────
+
+/**
+ * Costruisce l'XML per la chiusura giornaliera (Z report).
+ * La trasmissione dati all'Agenzia delle Entrate avviene automaticamente.
+ * @param {object} job
+ * @returns {string}
+ */
+function formatZReport(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  const timeout = Number(job.timeout) > 0 ? Number(job.timeout) : 30000;
+  return [
+    '<printerFiscalReport>',
+    `<printZReport operator="${escXml(operator)}" timeout="${timeout}" />`,
+    '</printerFiscalReport>',
+  ].join('\n');
+}
+
+/**
+ * Costruisce l'XML per il report finanziario giornaliero (X report, non fiscale).
+ * @param {object} job
+ * @returns {string}
+ */
+function formatXReport(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  return [
+    '<printerFiscalReport>',
+    `<printXReport operator="${escXml(operator)}" />`,
+    '</printerFiscalReport>',
+  ].join('\n');
+}
+
+// ── Printer status query ─────────────────────────────────────────────────────
+
+/**
+ * Costruisce l'XML per la query dello stato della stampante.
+ * @param {object} job
+ * @param {'0'|'1'} [job.statusType]  '0' = base, '1' = RT (default '0')
+ * @returns {string}
+ */
+function formatStatusQuery(job) {
+  const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
+  const statusType = job.statusType === '1' ? '1' : '0';
+  return [
+    '<printerCommand>',
+    `<queryPrinterStatus operator="${escXml(operator)}" statusType="${statusType}" />`,
+    '</printerCommand>',
+  ].join('\n');
+}
+
+// ── Dispatch ─────────────────────────────────────────────────────────────────
+
+/**
+ * Seleziona il formatter XML corretto in base al printType del job.
+ * @param {object} job
+ * @returns {string} XML string
+ * @throws {Error} se il printType non è supportato
+ */
+function buildFiscalXml(job) {
+  switch (job.printType) {
+    case 'fiscal_receipt':  return formatFiscalReceipt(job);
+    case 'fiscal_z_report': return formatZReport(job);
+    case 'fiscal_x_report': return formatXReport(job);
+    case 'fiscal_status':   return formatStatusQuery(job);
+    default: {
+      const err = new Error(`Tipo fiscale non supportato: ${job.printType}`);
+      err.permanent = true;
+      throw err;
+    }
+  }
+}
+
+module.exports = {
+  buildFiscalXml,
+  formatFiscalReceipt,
+  formatZReport,
+  formatXReport,
+  formatStatusQuery,
+  escXml,
+  formatAmount,
+  formatQuantity,
+  paymentTypeFromLabel,
+};

--- a/print-server/formatters/fiscal_receipt.js
+++ b/print-server/formatters/fiscal_receipt.js
@@ -36,6 +36,20 @@ function escXml(v) {
 }
 
 /**
+ * Converte un importo (numero o stringa con virgola/punto decimale) in number.
+ * Le stringhe italiane tipo "10,00" verrebbero altrimenti da `Number()` come NaN,
+ * facendo scartare il pagamento dal filtro `> 0` (errore "almeno un pagamento").
+ * @param {number|string} value
+ * @returns {number} NaN se non numerico
+ */
+function toAmountNumber(value) {
+  if (typeof value === 'string') {
+    return Number(value.replace(',', '.'));
+  }
+  return Number(value);
+}
+
+/**
  * Formatta un importo numerico con due decimali usando la virgola come
  * separatore decimale (convenzione italiana richiesta dalla stampante).
  * Accetta anche stringhe già formattate, normalizzando il separatore.
@@ -111,7 +125,7 @@ function formatFiscalReceipt(job) {
   const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
   const orders = Array.isArray(job.orders) ? job.orders : [];
   const items = orders.flatMap((o) => Array.isArray(o?.items) ? o.items : []);
-  const payments = Array.isArray(job.payments) ? job.payments.filter((p) => p && Number(p.amount) > 0) : [];
+  const payments = Array.isArray(job.payments) ? job.payments.filter((p) => p && toAmountNumber(p.amount) > 0) : [];
 
   if (items.length === 0) {
     throw new Error('fiscal_receipt: almeno una voce di vendita è obbligatoria');
@@ -287,7 +301,7 @@ function formatFiscalRefund(job) {
   const operator = job.operator != null && job.operator !== '' ? String(job.operator) : '1';
   const orders = Array.isArray(job.orders) ? job.orders : [];
   const items = orders.flatMap((o) => Array.isArray(o?.items) ? o.items : []);
-  const payments = Array.isArray(job.payments) ? job.payments.filter((p) => p && Number(p.amount) > 0) : [];
+  const payments = Array.isArray(job.payments) ? job.payments.filter((p) => p && toAmountNumber(p.amount) > 0) : [];
   const ref = job.receiptRef ?? null;
 
   if (items.length === 0) throw new Error('fiscal_refund: almeno una voce di reso è obbligatoria');
@@ -450,4 +464,5 @@ module.exports = {
   formatQuantity,
   normalizeRefDate,
   paymentTypeFromLabel,
+  toAmountNumber,
 };

--- a/print-server/fpmate-client.js
+++ b/print-server/fpmate-client.js
@@ -1,0 +1,212 @@
+'use strict';
+
+/**
+ * @file fpmate-client.js
+ * @description Transport HTTP/SOAP per la stampante fiscale Epson RT (fpmate.cgi).
+ *
+ * Il servizio fpmate.cgi risiede nel web server integrato della stampante fiscale
+ * e accetta richieste SOAP/HTTP POST con body XML (Fiscal ePOS-Print XML).
+ *
+ * Endpoint: http(s)://<host>/cgi-bin/fpmate.cgi?timeout=<ms>
+ *
+ * La busta SOAP viene aggiunta qui attorno all'XML prodotto dai formatter
+ * (formatters/fiscal_receipt.js), così i formatter rimangono agnostici al transport.
+ *
+ * Esporta:
+ *   sendFiscalRequest({ xml, host, timeout?, port?, https?, username?, password? })
+ *     → Promise<FiscalResponse>
+ *
+ *   wrapSoapEnvelope(xml)
+ *   parseFiscalResponse(xmlString)
+ *   buildFpmateUrl(host, opts)
+ *
+ * FiscalResponse:
+ *   { success: boolean, code: string, status: string,
+ *     addInfo: object,    // mappa dei campi <addInfo> (fiscalReceiptNumber, …)
+ *     raw: string }       // XML risposta completo
+ */
+
+const http = require('http');
+const https = require('https');
+
+const SOAP_ENVELOPE_PREFIX = `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body>`;
+
+const SOAP_ENVELOPE_SUFFIX = `</s:Body></s:Envelope>`;
+
+/**
+ * Incapsula un XML fiscale in una busta SOAP, come richiesto da fpmate.cgi.
+ * @param {string} xml
+ * @returns {string}
+ */
+function wrapSoapEnvelope(xml) {
+  return SOAP_ENVELOPE_PREFIX + xml + SOAP_ENVELOPE_SUFFIX;
+}
+
+/**
+ * Costruisce l'URL del servizio fpmate.cgi.
+ * @param {string} host
+ * @param {{ port?: number|string, https?: boolean, timeout?: number|string }} opts
+ * @returns {string}
+ */
+function buildFpmateUrl(host, opts = {}) {
+  const useHttps = opts.https === true;
+  const port = opts.port != null && opts.port !== '' ? `:${opts.port}` : '';
+  const base = `${useHttps ? 'https' : 'http'}://${host}${port}/cgi-bin/fpmate.cgi`;
+  if (opts.timeout != null && opts.timeout !== '') {
+    return `${base}?timeout=${encodeURIComponent(String(opts.timeout))}`;
+  }
+  return base;
+}
+
+/**
+ * Estrae il testo contenuto in un tag XML, gestendo i namespace e gli
+ * attributi del tag di apertura. Restituisce null se il tag non è presente.
+ * @param {string} xml
+ * @param {string} tagName
+ * @returns {string|null}
+ */
+function extractTagContent(xml, tagName) {
+  // Match <tagName ...>content</tagName> (anche su più righe), tollerando
+  // attributi e prefissi namespace. Non usa dipendenze esterne per parsing XML.
+  const re = new RegExp(`<${tagName}(?:\\s[^>]*)?>([\\s\\S]*?)</${tagName}>`, 'i');
+  const m = xml.match(re);
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * Parsa la risposta XML di fpmate.cgi estraendo gli attributi di <response>
+ * e i campi di <addInfo>.
+ *
+ * Struttura tipica:
+ *   <response success="true" code="" status="2">
+ *     <addInfo>
+ *       <elementList>a,b,c</elementList>
+ *       <a>..</a><b>..</b><c>..</c>
+ *     </addInfo>
+ *   </response>
+ *
+ * In caso di errore, <response> ha success="false" e code valorizzato
+ * (es. PRINTER ERROR, INCOMPLETE FILE, …).
+ *
+ * @param {string} xmlString
+ * @returns {{ success: boolean, code: string, status: string, addInfo: Record<string,string>, raw: string }}
+ */
+function parseFiscalResponse(xmlString) {
+  const raw = typeof xmlString === 'string' ? xmlString : '';
+  const success = /\ssuccess="true"/i.test(raw);
+  const codeMatch = raw.match(/\scode="([^"]*)"/i);
+  const statusMatch = raw.match(/\sstatus="([^"]*)"/i);
+  const code = codeMatch ? codeMatch[1] : '';
+  const status = statusMatch ? statusMatch[1] : '';
+
+  const addInfo = {};
+  const elementList = extractTagContent(raw, 'elementList');
+  if (elementList) {
+    const names = elementList.split(',').map((s) => s.trim()).filter(Boolean);
+    for (const name of names) {
+      const value = extractTagContent(raw, name);
+      if (value != null) addInfo[name] = value;
+    }
+  }
+
+  return { success, code, status, addInfo, raw };
+}
+
+/**
+ * Invia una richiesta XML fiscale alla stampante tramite fpmate.cgi.
+ *
+ * @param {object} options
+ * @param {string} options.xml        XML fiscale (senza envelope SOAP)
+ * @param {string} options.host       IP/hostname della stampante fiscale
+ * @param {number|string} [options.timeout]  Timeout query-string in ms (default 30000)
+ * @param {number|string} [options.port]     Porta HTTP (default: nessuna → 80/443)
+ * @param {boolean} [options.https]   Usa HTTPS (default false)
+ * @param {string} [options.username] Credenziali (autenticazione web opzionale)
+ * @param {string} [options.password]
+ * @param {number} [options.requestTimeoutMs] Timeout socket lato client (default timeout+10000)
+ * @returns {Promise<{ success: boolean, code: string, status: string, addInfo: object, raw: string }>}
+ */
+function sendFiscalRequest(options) {
+  const {
+    xml,
+    host,
+    timeout = 30000,
+    port,
+    https: useHttps = false,
+    username,
+    password,
+  } = options;
+
+  if (!xml || typeof xml !== 'string') {
+    return Promise.reject(new Error('fpmate: xml payload mancante'));
+  }
+  if (!host) {
+    return Promise.reject(new Error('fpmate: host stampante fiscale mancante'));
+  }
+
+  const body = wrapSoapEnvelope(xml);
+  const url = buildFpmateUrl(host, { port, https: useHttps, timeout });
+  const requestTimeoutMs = Number(options.requestTimeoutMs) > 0
+    ? Number(options.requestTimeoutMs)
+    : Number(timeout) + 10000;
+
+  const lib = useHttps ? https : http;
+  const parsedUrl = new URL(url);
+  const requestOptions = {
+    method: 'POST',
+    hostname: parsedUrl.hostname,
+    port: parsedUrl.port || (useHttps ? 443 : 80),
+    path: parsedUrl.pathname + parsedUrl.search,
+    headers: {
+      'Content-Type': 'text/xml; charset=utf-8',
+      'Content-Length': Buffer.byteLength(body, 'utf8'),
+      'If-Modified-Since': 'Thu, 01 Jan 1970 00:00:00 GMT',
+    },
+    timeout: requestTimeoutMs,
+  };
+
+  if (username) {
+    const auth = Buffer.from(`${username}:${password ?? ''}`).toString('base64');
+    requestOptions.headers.Authorization = `Basic ${auth}`;
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = lib.request(requestOptions, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        const responseText = Buffer.concat(chunks).toString('utf8');
+        if (res.statusCode == null || res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(
+            `fpmate: HTTP ${res.statusCode} da ${host}. Body: ${responseText.slice(0, 200)}`
+          ));
+          return;
+        }
+        try {
+          resolve(parseFiscalResponse(responseText));
+        } catch (err) {
+          reject(new Error(`fpmate: risposta XML non valida da ${host}: ${err.message}`));
+        }
+      });
+    });
+
+    req.on('timeout', () => {
+      req.destroy(new Error(`fpmate: timeout (${requestTimeoutMs}ms) comunicando con ${host}`));
+    });
+    req.on('error', (err) => {
+      reject(err);
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+module.exports = {
+  sendFiscalRequest,
+  wrapSoapEnvelope,
+  buildFpmateUrl,
+  parseFiscalResponse,
+  extractTagContent,
+};

--- a/print-server/fpmate-client.js
+++ b/print-server/fpmate-client.js
@@ -155,10 +155,17 @@ function sendFiscalRequest(options) {
   }
 
   const body = wrapSoapEnvelope(xml);
-  const url = buildFpmateUrl(host, { port, https: useHttps, timeout });
-  const requestTimeoutMs = Number(options.requestTimeoutMs) > 0
+  // Validate `timeout` before using it in arithmetic: the JSDoc allows a string,
+  // so a non-numeric value would make Number(timeout) = NaN and the client
+  // socket timeout (requestTimeoutMs) would silently become NaN. Coerce to a
+  // finite positive number, falling back to the default (30000) when invalid.
+  const timeoutMs = Number.isFinite(Number(timeout)) && Number(timeout) > 0
+    ? Number(timeout)
+    : 30000;
+  const url = buildFpmateUrl(host, { port, https: useHttps, timeout: timeoutMs });
+  const requestTimeoutMs = Number.isFinite(Number(options.requestTimeoutMs)) && Number(options.requestTimeoutMs) > 0
     ? Number(options.requestTimeoutMs)
-    : Number(timeout) + 10000;
+    : timeoutMs + 10000;
 
   const lib = useHttps ? https : http;
   const parsedUrl = new URL(url);

--- a/print-server/fpmate-client.js
+++ b/print-server/fpmate-client.js
@@ -69,7 +69,11 @@ function buildFpmateUrl(host, opts = {}) {
 function extractTagContent(xml, tagName) {
   // Match <tagName ...>content</tagName> (anche su più righe), tollerando
   // attributi e prefissi namespace. Non usa dipendenze esterne per parsing XML.
-  const re = new RegExp(`<${tagName}(?:\\s[^>]*)?>([\\s\\S]*?)</${tagName}>`, 'i');
+  // tagName proviene da <elementList> nella risposta del dispositivo: escape i
+  // metacaratteri regex prima di costruire il pattern e tollera un eventuale
+  // prefisso `ns:` su entrambi i tag di apertura/chiusura.
+  const escaped = String(tagName).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`<(?:[\\w-]+:)?${escaped}(?:\\s[^>]*)?>([\\s\\S]*?)</(?:[\\w-]+:)?${escaped}>`, 'i');
   const m = xml.match(re);
   return m ? m[1].trim() : null;
 }

--- a/print-server/fpmate-client.js
+++ b/print-server/fpmate-client.js
@@ -98,9 +98,14 @@ function extractTagContent(xml, tagName) {
  */
 function parseFiscalResponse(xmlString) {
   const raw = typeof xmlString === 'string' ? xmlString : '';
-  const success = /\ssuccess="true"/i.test(raw);
-  const codeMatch = raw.match(/\scode="([^"]*)"/i);
-  const statusMatch = raw.match(/\sstatus="([^"]*)"/i);
+  // Extract only the opening <response ...> tag so that success/code/status
+  // attributes are not mistakenly matched against unrelated tags elsewhere in
+  // the XML body (e.g. nested <addInfo> elements carrying similar attributes).
+  const responseTagMatch = raw.match(/<response\b[^>]*>/i);
+  const responseTag = responseTagMatch ? responseTagMatch[0] : '';
+  const success = /\ssuccess="true"/i.test(responseTag);
+  const codeMatch = responseTag.match(/\scode="([^"]*)"/i);
+  const statusMatch = responseTag.match(/\sstatus="([^"]*)"/i);
   const code = codeMatch ? codeMatch[1] : '';
   const status = statusMatch ? statusMatch[1] : '';
 

--- a/print-server/printer.js
+++ b/print-server/printer.js
@@ -92,7 +92,12 @@ function loadPrintersFromEnv() {
     if (type === 'file') {
       entry.device = process.env[`PRINTER_${n}_DEVICE`] || '/dev/usb/lp0';
     } else if (type === 'fpmate') {
-      entry.host = process.env[`PRINTER_${n}_HOST`] || '127.0.0.1';
+      // host is required for fpmate (the fiscal printer address). Don't silently
+      // default to 127.0.0.1 — that masks a misconfiguration and fails later with
+      // a confusing connection error or hits the wrong device. Leave it unset so
+      // the dispatch path can reject with a clear message.
+      const fpmateHost = process.env[`PRINTER_${n}_HOST`];
+      if (fpmateHost) entry.host = fpmateHost;
       const rawPort = process.env[`PRINTER_${n}_PORT`];
       const parsedPort = parseInt(rawPort, 10);
       entry.port = rawPort && !isNaN(parsedPort) ? parsedPort : null;
@@ -386,6 +391,11 @@ function printFiscal(xmlPayload, printerId) {
   if ((config.type || '').toLowerCase() !== 'fpmate') {
     return Promise.reject(
       new Error(`La stampante "${config.id}" non è di tipo fpmate (type="${config.type}").`)
+    );
+  }
+  if (!config.host) {
+    return Promise.reject(
+      new Error(`Configurazione fpmate incompleta per la stampante "${config.id}": manca PRINTER_<N>_HOST (host della stampante fiscale).`)
     );
   }
   return _enqueue(config.id, () => printViaFpmate(xmlPayload, config));

--- a/print-server/printer.js
+++ b/print-server/printer.js
@@ -6,8 +6,9 @@
  *
  * Legge il registro delle stampanti da `printers.config.js`.
  * Ogni stampante può essere raggiunta tramite:
- *   - TCP  (type: 'tcp')  → connessione socket sulla porta 9100 (o custom)
- *   - File (type: 'file') → scrittura su file di dispositivo (/dev/usb/lp0)
+ *   - TCP    (type: 'tcp')    → connessione socket sulla porta 9100 (o custom)
+ *   - File   (type: 'file')   → scrittura su file di dispositivo (/dev/usb/lp0)
+ *   - Fpmate (type: 'fpmate') → stampante fiscale Epson RT via HTTP/SOAP fpmate.cgi
  *
  * Jobs to the same physical printer are serialized via a per-printer promise queue
  * to prevent interleaved output when concurrent requests arrive.
@@ -31,6 +32,7 @@
 
 const net = require('net');
 const fs  = require('fs');
+const { sendFiscalRequest } = require('./fpmate-client.js');
 
 // ── Lookup stampante ─────────────────────────────────────────────────────────
 
@@ -58,13 +60,20 @@ function findPrinterConfig(printersList, printerId) {
  * Convention: indexed entries starting from 0.
  *   PRINTER_0_ID      – (required) unique printer id
  *   PRINTER_0_NAME    – display name (default: same as ID)
- *   PRINTER_0_TYPE    – 'tcp' | 'file' (default: 'tcp')
+ *   PRINTER_0_TYPE    – 'tcp' | 'file' | 'fpmate' (default: 'tcp')
  *   For type='tcp':
  *     PRINTER_0_HOST    – IP or hostname (default: '127.0.0.1')
  *     PRINTER_0_PORT    – TCP port (default: 9100)
  *     PRINTER_0_TIMEOUT – connection timeout in ms (default: 5000)
  *   For type='file':
  *     PRINTER_0_DEVICE  – device path (default: '/dev/usb/lp0')
+ *   For type='fpmate' (stampante fiscale Epson RT via fpmate.cgi):
+ *     PRINTER_0_HOST    – IP/hostname della stampante fiscale (obbligatorio)
+ *     PRINTER_0_PORT    – porta HTTP (default: nessuna → 80/443)
+ *     PRINTER_0_TIMEOUT – timeout fpmate query-string in ms (default: 30000)
+ *     PRINTER_0_HTTPS   – '1'/'true' per HTTPS (default: false)
+ *     PRINTER_0_USERNAME – credenziali web opzionali
+ *     PRINTER_0_PASSWORD – credenziali web opzionali
  *
  * Iteration stops at the first missing PRINTER_<N>_ID.
  * Returns an empty array when no printer env vars are set.
@@ -82,6 +91,17 @@ function loadPrintersFromEnv() {
     const entry = { id, name, type };
     if (type === 'file') {
       entry.device = process.env[`PRINTER_${n}_DEVICE`] || '/dev/usb/lp0';
+    } else if (type === 'fpmate') {
+      entry.host = process.env[`PRINTER_${n}_HOST`] || '127.0.0.1';
+      const rawPort = process.env[`PRINTER_${n}_PORT`];
+      const parsedPort = parseInt(rawPort, 10);
+      entry.port = rawPort && !isNaN(parsedPort) ? parsedPort : null;
+      const rawTimeout = process.env[`PRINTER_${n}_TIMEOUT`];
+      const parsedTimeout = parseInt(rawTimeout, 10);
+      entry.timeout = rawTimeout && !isNaN(parsedTimeout) ? parsedTimeout : 30000;
+      entry.https = /^(1|true)$/i.test(process.env[`PRINTER_${n}_HTTPS`] || '');
+      entry.username = process.env[`PRINTER_${n}_USERNAME`] || '';
+      entry.password = process.env[`PRINTER_${n}_PASSWORD`] || '';
     } else {
       entry.host = process.env[`PRINTER_${n}_HOST`] || '127.0.0.1';
       const rawPort    = process.env[`PRINTER_${n}_PORT`];
@@ -140,13 +160,20 @@ function _resetPrinterCache() {
  *   Ogni voce deve avere:
  *     id       {string}           — identificatore univoco
  *     name     {string}           — nome descrittivo
- *     type     {'tcp'|'file'}     — tipo di connessione
+ *     type     {'tcp'|'file'|'fpmate'} — tipo di connessione
  *     For type='tcp':
  *       host    {string}          — IP/hostname (default: '127.0.0.1')
  *       port    {number}          — porta TCP (default: 9100)
  *       timeout {number}          — timeout in ms (default: 5000)
  *     For type='file':
  *       device  {string}          — percorso device (default: '/dev/usb/lp0')
+ *     For type='fpmate' (stampante fiscale Epson RT):
+ *       host    {string}          — IP/hostname stampante fiscale
+ *       port    {number|null}     — porta HTTP (default: null → 80/443)
+ *       timeout {number}          — timeout fpmate in ms (default: 30000)
+ *       https   {boolean}         — usa HTTPS (default: false)
+ *       username {string}         — credenziali web (opzionale)
+ *       password {string}         — credenziali web (opzionale)
  */
 function setPrinters(list) {
   const printers = Array.isArray(list) ? list : [];
@@ -242,13 +269,17 @@ function _dispatch(buf, config) {
   }
 
   const type = rawType.toLowerCase();
-  if (type !== 'tcp' && type !== 'file') {
+  if (type !== 'tcp' && type !== 'file' && type !== 'fpmate') {
     throw new Error(
-      `Invalid printer type for printer "${config.id}": expected "tcp" or "file", got "${rawType}".`
+      `Invalid printer type for printer "${config.id}": expected "tcp", "file" or "fpmate", got "${rawType}".`
     );
   }
   if (type === 'file') {
     return printToFile(buf, config.device || '/dev/usb/lp0');
+  }
+  if (type === 'fpmate') {
+    // buf is the raw fiscal XML string encoded as UTF-8 Buffer.
+    return printViaFpmate(buf, config);
   }
   return printViaTcp(
     buf,
@@ -314,5 +345,51 @@ function printToFile(buf, device) {
   });
 }
 
-module.exports = { printBuffer, getPrintersList, getPrinterConfig, findPrinterConfig, loadPrintersFromEnv, setPrinters, _enqueue, _dispatch, _resetPrinterCache };
+// ── Stampante fiscale fpmate.cgi ─────────────────────────────────────────────
+
+/**
+ * Invia un payload XML fiscale alla stampante Epson RT via fpmate.cgi.
+ * Il Buffer `buf` deve contenere l'XML (UTF-8) prodotto dai formatter fiscali.
+ * Restituisce la risposta parsata della stampante (con fiscalReceiptNumber, ecc.).
+ *
+ * @param {Buffer|string} buf  XML fiscale (Buffer UTF-8 o stringa)
+ * @param {object} config      configurazione stampante (host, timeout, https, …)
+ * @returns {Promise<object>} risposta fpmate { success, code, status, addInfo, raw }
+ */
+function printViaFpmate(buf, config) {
+  const xml = Buffer.isBuffer(buf) ? buf.toString('utf8') : String(buf);
+  return sendFiscalRequest({
+    xml,
+    host: config.host,
+    port: config.port,
+    timeout: config.timeout || 30000,
+    https: config.https === true,
+    username: config.username || undefined,
+    password: config.password || undefined,
+  });
+}
+
+/**
+ * Invia un job fiscale (XML) alla stampante fiscale identificata da `printerId`.
+ * Serializza i job per la stessa stampante (come printBuffer) per evitare
+ * emissioni fiscali concorrenti (es. Z report durante uno scontrino).
+ *
+ * @param {Buffer|string} xmlPayload  XML fiscale
+ * @param {string} printerId         id stampante fpmate
+ * @returns {Promise<object>} risposta fpmate
+ */
+function printFiscal(xmlPayload, printerId) {
+  const config = getPrinterConfig(printerId);
+  if (!config) {
+    return Promise.reject(new Error('No printers configured in printers.config.js.'));
+  }
+  if ((config.type || '').toLowerCase() !== 'fpmate') {
+    return Promise.reject(
+      new Error(`La stampante "${config.id}" non è di tipo fpmate (type="${config.type}").`)
+    );
+  }
+  return _enqueue(config.id, () => printViaFpmate(xmlPayload, config));
+}
+
+module.exports = { printBuffer, printFiscal, printViaFpmate, getPrintersList, getPrinterConfig, findPrinterConfig, loadPrintersFromEnv, setPrinters, _enqueue, _dispatch, _resetPrinterCache };
 

--- a/print-server/printer.js
+++ b/print-server/printer.js
@@ -34,6 +34,11 @@ const net = require('net');
 const fs  = require('fs');
 const { sendFiscalRequest } = require('./fpmate-client.js');
 
+// Printers can be configured via PRINTER_<N>_* env vars, printers.config.js,
+// or Directus hydration — keep the "no printers" message source-agnostic so it
+// doesn't point operators at the wrong configuration source.
+const NO_PRINTERS_CONFIGURED_ERROR = 'No printers configured (set PRINTER_<N>_* env vars, printers.config.js, or Directus).';
+
 // ── Lookup stampante ─────────────────────────────────────────────────────────
 
 /**
@@ -254,7 +259,7 @@ function _enqueue(id, fn) {
 function printBuffer(buf, printerId) {
   const config = getPrinterConfig(printerId);
   if (!config) {
-    return Promise.reject(new Error('No printers configured in printers.config.js.'));
+    return Promise.reject(new Error(NO_PRINTERS_CONFIGURED_ERROR));
   }
   return _enqueue(config.id, () => _dispatch(buf, config));
 }
@@ -386,7 +391,7 @@ function printViaFpmate(buf, config) {
 function printFiscal(xmlPayload, printerId) {
   const config = getPrinterConfig(printerId);
   if (!config) {
-    return Promise.reject(new Error('No printers configured in printers.config.js.'));
+    return Promise.reject(new Error(NO_PRINTERS_CONFIGURED_ERROR));
   }
   if ((config.type || '').toLowerCase() !== 'fpmate') {
     return Promise.reject(
@@ -395,11 +400,11 @@ function printFiscal(xmlPayload, printerId) {
   }
   if (!config.host) {
     return Promise.reject(
-      new Error(`Configurazione fpmate incompleta per la stampante "${config.id}": manca PRINTER_<N>_HOST (host della stampante fiscale).`)
+      new Error(`Configurazione fpmate incompleta per la stampante "${config.id}": manca l'host della stampante fiscale (configurare PRINTER_<N>_HOST o l'equivalente in printers.config.js / Directus).`)
     );
   }
   return _enqueue(config.id, () => printViaFpmate(xmlPayload, config));
 }
 
-module.exports = { printBuffer, printFiscal, printViaFpmate, getPrintersList, getPrinterConfig, findPrinterConfig, loadPrintersFromEnv, setPrinters, _enqueue, _dispatch, _resetPrinterCache };
+module.exports = { printBuffer, printFiscal, printViaFpmate, getPrintersList, getPrinterConfig, findPrinterConfig, loadPrintersFromEnv, setPrinters, _enqueue, _dispatch, _resetPrinterCache, NO_PRINTERS_CONFIGURED_ERROR };
 

--- a/print-server/printer.js
+++ b/print-server/printer.js
@@ -261,6 +261,15 @@ function printBuffer(buf, printerId) {
   if (!config) {
     return Promise.reject(new Error(NO_PRINTERS_CONFIGURED_ERROR));
   }
+  // printBuffer riceve buffer ESC/POS (es. da directus-client). Una stampante
+  // fpmate accetta solo XML fiscale via SOAP: inviarle byte ESC/POS produrrebbe
+  // XML/SOAP non valido rompendo la spedizione. I job fiscali devono usare
+  // printFiscal(); qui rifiutiamo esplicitamente le stampanti fpmate.
+  if ((config.type || '').toLowerCase() === 'fpmate') {
+    return Promise.reject(
+      new Error(`La stampante "${config.id}" è di tipo fpmate: usare printFiscal() per i job fiscali, non printBuffer().`)
+    );
+  }
   return _enqueue(config.id, () => _dispatch(buf, config));
 }
 

--- a/print-server/printers.config.js
+++ b/print-server/printers.config.js
@@ -11,7 +11,7 @@
  * Proprietà di ogni stampante:
  *   id       {string}  – identificatore univoco (deve corrispondere a appConfig.printers[].id)
  *   name     {string}  – nome descrittivo (solo per i log)
- *   type     {string}  – 'tcp' (rete) | 'file' (dispositivo USB/parallelo)
+ *   type     {string}  – 'tcp' (rete) | 'file' (USB/parallelo) | 'fpmate' (fiscale RT)
  *
  *   Per type='tcp':
  *     host    {string}  – indirizzo IP o hostname della stampante
@@ -21,12 +21,26 @@
  *   Per type='file':
  *     device  {string}  – percorso del file di dispositivo (es. '/dev/usb/lp0')
  *
+ *   Per type='fpmate' (stampante fiscale Epson RT via fpmate.cgi):
+ *     host     {string}         – IP/hostname della stampante fiscale
+ *     port     {number|null}    – porta HTTP (default: null → 80/443)
+ *     timeout  {number}         – timeout fpmate in ms (default: 30000)
+ *     https    {boolean}        – usa HTTPS (default: false)
+ *     username {string}         – credenziali web (opzionale)
+ *     password {string}         – credenziali web (opzionale)
+ *
  * Esempio configurazione multi-stampante (cucina + bar + cassa):
  *
  *   printers: [
  *     { id: 'cucina', name: 'Cucina',  type: 'tcp',  host: '192.168.1.100', port: 9100 },
  *     { id: 'bar',    name: 'Bar',     type: 'tcp',  host: '192.168.1.101', port: 9100 },
  *     { id: 'cassa',  name: 'Cassa',   type: 'file', device: '/dev/usb/lp0' },
+ *   ],
+ *
+ * Esempio stampante fiscale Epson RT (fpmate):
+ *
+ *   printers: [
+ *     { id: 'fiscale', name: 'Stampante Fiscale', type: 'fpmate', host: '192.168.1.200' },
  *   ],
  *
  * Se il `printerId` del job non corrisponde a nessuna voce, viene usata la prima

--- a/print-server/server.js
+++ b/print-server/server.js
@@ -142,8 +142,9 @@ function sanitizeForLog(v) {
 // ── Optional API key middleware ───────────────────────────────────────────────
 
 /**
- * If PRINT_SERVER_API_KEY is configured, every POST /print request must include
- * the matching x-api-key header; all other requests (e.g. GET /health) pass through.
+ * If PRINT_SERVER_API_KEY is configured, guarded routes (POST /print and
+ * GET /printers) must include the matching x-api-key header; all other
+ * requests (e.g. GET /health) pass through.
  */
 function apiKeyGuard(req, res, next) {
   if (!API_KEY || req.method === 'OPTIONS') return next();
@@ -165,8 +166,10 @@ app.get('/health', (_req, res) => {
 /**
  * GET /printers
  * Restituisce l'elenco delle stampanti configurate (senza credenziali).
+ * Protetto da apiKeyGuard quando PRINT_SERVER_API_KEY è configurato, per non
+ * esporre i dettagli di rete interna (host/port) a origini CORS arbitrarie.
  */
-app.get('/printers', (_req, res) => {
+app.get('/printers', apiKeyGuard, (_req, res) => {
   const printers = getPrintersList().map((p) => {
     const summary = { id: p.id, name: p.name, type: p.type };
     if (p.type === 'tcp') {

--- a/print-server/server.js
+++ b/print-server/server.js
@@ -139,6 +139,20 @@ function sanitizeForLog(v) {
   return String(v).replace(/[\r\n\t\x00-\x1f\x7f]/g, ' ').slice(0, 64);
 }
 
+/**
+ * Builds a human-readable error message from an fpmate application-level
+ * failure (HTTP 200 but success=false), prioritizing the printer's `code`
+ * (e.g. "PRINTER ERROR") and falling back to `status` when code is empty.
+ * @param {{ success: boolean, code?: string, status?: string, addInfo?: object }} fiscalResponse
+ * @returns {string}
+ */
+function buildFiscalErrorMessage(fiscalResponse) {
+  const code = fiscalResponse && typeof fiscalResponse.code === 'string' ? fiscalResponse.code.trim() : '';
+  const status = fiscalResponse && typeof fiscalResponse.status === 'string' ? fiscalResponse.status.trim() : '';
+  const detail = code || (status ? `status ${status}` : '');
+  return detail ? `Errore stampante fiscale: ${detail}` : 'Errore stampante fiscale.';
+}
+
 // ── Optional API key middleware ───────────────────────────────────────────────
 
 /**
@@ -274,10 +288,17 @@ app.post('/print', apiKeyGuard, async (req, res) => {
       const fiscalResponse = await printFiscal(xml, printerId);
       console.log('[print-server] Job fiscale stampato:', safeJobId, '(' + safePrintType + ') → stampante:', safeResolvedId,
         'success:', fiscalResponse.success, 'receipt:', fiscalResponse.addInfo?.fiscalReceiptNumber ?? '–');
+      // When the printer answers HTTP 200 but signals an application-level
+      // failure (success=false), surface an explicit error built from the
+      // fpmate code/status so the client does not fall back to a generic
+      // "HTTP 200" message and lose the real reason.
+      const ok = fiscalResponse.success === true;
+      const error = ok ? null : buildFiscalErrorMessage(fiscalResponse);
       return res.json({
-        ok: fiscalResponse.success === true,
+        ok,
         jobId: jobId ?? null,
         fiscal: fiscalResponse,
+        ...(error ? { error } : {}),
       });
     } catch (err) {
       const safeMsg = sanitizeForLog(err.message);
@@ -391,5 +412,5 @@ if (require.main === module) {
   });
 }
 
-module.exports = { app, server, buildPrinterSummary };
+module.exports = { app, server, buildPrinterSummary, buildFiscalErrorMessage };
 

--- a/print-server/server.js
+++ b/print-server/server.js
@@ -53,7 +53,7 @@ const http    = require('http');
 const cors    = require('cors');
 const express = require('express');
 
-const { printBuffer, printFiscal, getPrintersList, getPrinterConfig } = require('./printer.js');
+const { printBuffer, printFiscal, getPrintersList, getPrinterConfig, NO_PRINTERS_CONFIGURED_ERROR } = require('./printer.js');
 const { buildEscPosBuffer } = require('./build-buffer.js');
 const { buildFiscalXml } = require('./formatters/fiscal_receipt.js');
 const directusClient = require('./directus-client.js');
@@ -164,26 +164,47 @@ app.get('/health', (_req, res) => {
 });
 
 /**
+ * Builds the public summary of a printer for GET /printers.
+ *
+ * Exposes network details (host/port/device) only when the endpoint is
+ * protected by an API key; otherwise returns a safe id/name/type summary so
+ * that, with CORS open by default, an arbitrary web page can't enumerate
+ * internal network topology.
+ *
+ * @param {object} p        printer config entry
+ * @param {boolean} authed  whether the request is authenticated (API key set)
+ * @returns {object} safe public summary
+ */
+function buildPrinterSummary(p, authed) {
+  const summary = { id: p.id, name: p.name, type: p.type };
+  if (!authed) return summary;
+  if (p.type === 'tcp') {
+    summary.host = p.host;
+    summary.port = p.port;
+  } else if (p.type === 'file') {
+    summary.device = p.device;
+  } else if (p.type === 'fpmate') {
+    summary.host = p.host;
+    summary.port = p.port ?? null;
+    summary.https = p.https === true;
+  }
+  return summary;
+}
+
+/**
  * GET /printers
  * Restituisce l'elenco delle stampanti configurate (senza credenziali).
  * Protetto da apiKeyGuard quando PRINT_SERVER_API_KEY è configurato, per non
  * esporre i dettagli di rete interna (host/port) a origini CORS arbitrarie.
+ *
+ * Se PRINT_SERVER_API_KEY non è configurata, apiKeyGuard lascia passare ogni
+ * richiesta; con CORS aperto di default, una pagina web arbitraria potrebbe
+ * leggere i dettagli di rete interna. In quel caso si restituisce solo un
+ * sommario sicuro (id/name/type) senza host/port/device.
  */
 app.get('/printers', apiKeyGuard, (_req, res) => {
-  const printers = getPrintersList().map((p) => {
-    const summary = { id: p.id, name: p.name, type: p.type };
-    if (p.type === 'tcp') {
-      summary.host = p.host;
-      summary.port = p.port;
-    } else if (p.type === 'file') {
-      summary.device = p.device;
-    } else if (p.type === 'fpmate') {
-      summary.host = p.host;
-      summary.port = p.port ?? null;
-      summary.https = p.https === true;
-    }
-    return summary;
-  });
+  const authed = Boolean(API_KEY);
+  const printers = getPrintersList().map((p) => buildPrinterSummary(p, authed));
   res.json({ ok: true, printers });
 });
 
@@ -227,7 +248,7 @@ app.post('/print', apiKeyGuard, async (req, res) => {
   // and surface a 500 early if no printers are configured.
   const printerConfig = getPrinterConfig(printerId);
   if (!printerConfig) {
-    return res.status(500).json({ ok: false, error: 'No printers configured in printers.config.js.' });
+    return res.status(500).json({ ok: false, error: NO_PRINTERS_CONFIGURED_ERROR });
   }
   const safeResolvedId = sanitizeForLog(printerConfig.id);
 
@@ -324,45 +345,51 @@ app.use((err, req, res, _next) => {
 
 // ── Avvio server ──────────────────────────────────────────────────────────────
 
+// Boot the server only when run directly (`node server.js`), not when imported
+// by tests. Expose the pure summary helper for unit testing the redaction logic.
 const server = http.createServer(app);
 
-server.listen(PORT, () => {
-  console.log(`[print-server] ${SERVER_NAME} in ascolto su http://localhost:${PORT}`);
-  console.log(`[print-server] Endpoint: POST http://localhost:${PORT}/print`);
-  if (API_KEY) {
-    console.log('[print-server] Autenticazione API key abilitata (x-api-key)');
-  }
-  if (CORS_ALLOWED_ORIGINS.length > 0) {
-    console.log('[print-server] CORS origini consentite:', CORS_ALLOWED_ORIGINS.join(', '));
-  }
-
-  const printers = getPrintersList();
-  if (printers.length === 0) {
-    console.warn('[print-server] ATTENZIONE: nessuna stampante configurata in printers.config.js');
-  } else {
-    console.log(`[print-server] Stampanti configurate (${printers.length}):`);
-    for (const p of printers) {
-      let conn;
-      if (p.type === 'file') {
-        conn = `file → ${p.device}`;
-      } else if (p.type === 'fpmate') {
-        conn = `fpmate → ${p.https ? 'https' : 'http'}://${p.host}${p.port ? ':' + p.port : ''}`;
-      } else {
-        conn = `TCP  → ${p.host}:${p.port}`;
-      }
-      console.log(`[print-server]   [${p.id}] ${p.name}  (${conn})`);
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`[print-server] ${SERVER_NAME} in ascolto su http://localhost:${PORT}`);
+    console.log(`[print-server] Endpoint: POST http://localhost:${PORT}/print`);
+    if (API_KEY) {
+      console.log('[print-server] Autenticazione API key abilitata (x-api-key)');
     }
-  }
+    if (CORS_ALLOWED_ORIGINS.length > 0) {
+      console.log('[print-server] CORS origini consentite:', CORS_ALLOWED_ORIGINS.join(', '));
+    }
 
-  // Avvia modalità Directus Pull se DIRECTUS_URL e DIRECTUS_TOKEN sono impostati.
-  // La funzione è non bloccante: polling e WebSocket girano in background.
-  directusClient.start(console).catch((err) => {
-    console.error('[print-server] Errore avvio Directus pull mode:', err instanceof Error ? err.message : String(err), err);
+    const printers = getPrintersList();
+    if (printers.length === 0) {
+      console.warn('[print-server] ATTENZIONE: nessuna stampante configurata in printers.config.js');
+    } else {
+      console.log(`[print-server] Stampanti configurate (${printers.length}):`);
+      for (const p of printers) {
+        let conn;
+        if (p.type === 'file') {
+          conn = `file → ${p.device}`;
+        } else if (p.type === 'fpmate') {
+          conn = `fpmate → ${p.https ? 'https' : 'http'}://${p.host}${p.port ? ':' + p.port : ''}`;
+        } else {
+          conn = `TCP  → ${p.host}:${p.port}`;
+        }
+        console.log(`[print-server]   [${p.id}] ${p.name}  (${conn})`);
+      }
+    }
+
+    // Avvia modalità Directus Pull se DIRECTUS_URL e DIRECTUS_TOKEN sono impostati.
+    // La funzione è non bloccante: polling e WebSocket girano in background.
+    directusClient.start(console).catch((err) => {
+      console.error('[print-server] Errore avvio Directus pull mode:', err instanceof Error ? err.message : String(err), err);
+    });
   });
-});
 
-server.on('error', (err) => {
-  console.error(`[print-server] Errore avvio server sulla porta ${PORT}:`, err.message);
-  process.exit(1);
-});
+  server.on('error', (err) => {
+    console.error(`[print-server] Errore avvio server sulla porta ${PORT}:`, err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { app, server, buildPrinterSummary };
 

--- a/print-server/server.js
+++ b/print-server/server.js
@@ -4,9 +4,19 @@
  * @file server.js
  * @description Servizio Node.js ESC/POS per la stampa di comande da app-cassa.
  *
- * Espone un endpoint HTTP:
- *   POST /print  – riceve un job JSON, lo converte in ESC/POS e lo invia alla stampante.
- *   GET  /health – ritorna { status: 'ok' } per il controllo di salute del servizio.
+ * Espone endpoint HTTP:
+ *   POST /print    – riceve un job JSON, lo converte in ESC/POS (o XML fiscale)
+ *                    e lo invia alla stampante.
+ *   GET  /health   – ritorna { status: 'ok' } per il controllo di salute del servizio.
+ *   GET  /printers – ritorna l'elenco delle stampanti configurate.
+ *
+ * Tipi di stampa supportati (campo `printType` del job):
+ *   ESC/POS (stampanti termiche tcp/file): 'order', 'table_move', 'pre_bill'
+ *   Fiscali (stampante Epson RT tipo fpmate):
+ *     'fiscal_receipt'  – scontrino fiscale (documento commerciale)
+ *     'fiscal_z_report' – chiusura giornaliera (Z report)
+ *     'fiscal_x_report' – report finanziario (X report)
+ *     'fiscal_status'   – query stato stampante
  *
  * Le stampanti fisiche sono configurate in `printers.config.js` (Opzione A) oppure
  * tramite variabili d'ambiente `PRINTER_<N>_*` (Opzione B — le env vars hanno la precedenza).
@@ -38,8 +48,9 @@ const http    = require('http');
 const cors    = require('cors');
 const express = require('express');
 
-const { printBuffer, getPrintersList, getPrinterConfig } = require('./printer.js');
+const { printBuffer, printFiscal, getPrintersList, getPrinterConfig } = require('./printer.js');
 const { buildEscPosBuffer } = require('./build-buffer.js');
+const { buildFiscalXml } = require('./formatters/fiscal_receipt.js');
 const directusClient = require('./directus-client.js');
 
 // ── Configurazione ────────────────────────────────────────────────────────────
@@ -77,7 +88,10 @@ const CORS_ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || '')
   .filter(Boolean);
 
 // Supported printType values
-const VALID_PRINT_TYPES = new Set(['order', 'table_move', 'pre_bill']);
+const VALID_PRINT_TYPES = new Set(['order', 'table_move', 'pre_bill', 'fiscal_receipt', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status']);
+
+// Fiscal print types — dispatched via fpmate HTTP/SOAP instead of raw ESC/POS.
+const FISCAL_PRINT_TYPES = new Set(['fiscal_receipt', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status']);
 
 // ── App Express ───────────────────────────────────────────────────────────────
 
@@ -144,6 +158,28 @@ app.get('/health', (_req, res) => {
 });
 
 /**
+ * GET /printers
+ * Restituisce l'elenco delle stampanti configurate (senza credenziali).
+ */
+app.get('/printers', (_req, res) => {
+  const printers = getPrintersList().map((p) => {
+    const summary = { id: p.id, name: p.name, type: p.type };
+    if (p.type === 'tcp') {
+      summary.host = p.host;
+      summary.port = p.port;
+    } else if (p.type === 'file') {
+      summary.device = p.device;
+    } else if (p.type === 'fpmate') {
+      summary.host = p.host;
+      summary.port = p.port ?? null;
+      summary.https = p.https === true;
+    }
+    return summary;
+  });
+  res.json({ ok: true, printers });
+});
+
+/**
  * POST /print
  * Riceve un job di stampa JSON, lo converte in ESC/POS e lo invia alla stampante.
  *
@@ -187,7 +223,41 @@ app.post('/print', apiKeyGuard, async (req, res) => {
   }
   const safeResolvedId = sanitizeForLog(printerConfig.id);
 
-  // Conversione payload → Buffer ESC/POS
+  // ── Fiscal jobs: build XML and dispatch via fpmate HTTP/SOAP ───────────────
+  if (FISCAL_PRINT_TYPES.has(printType)) {
+    if ((printerConfig.type || '').toLowerCase() !== 'fpmate') {
+      return res.status(400).json({
+        ok: false,
+        error: `Il printType "${printType}" richiede una stampante di tipo fpmate (stampante "${printerConfig.id}" è type="${printerConfig.type}").`,
+      });
+    }
+
+    let xml;
+    try {
+      xml = buildFiscalXml(job);
+    } catch (err) {
+      const safeMsg = sanitizeForLog(err.message);
+      console.error('[print-server] Errore formattazione fiscale job', safeJobId, '(' + safePrintType + '):', safeMsg);
+      return res.status(400).json({ ok: false, error: `Errore formattazione fiscale: ${safeMsg}` });
+    }
+
+    try {
+      const fiscalResponse = await printFiscal(xml, printerId);
+      console.log('[print-server] Job fiscale stampato:', safeJobId, '(' + safePrintType + ') → stampante:', safeResolvedId,
+        'success:', fiscalResponse.success, 'receipt:', fiscalResponse.addInfo?.fiscalReceiptNumber ?? '–');
+      return res.json({
+        ok: fiscalResponse.success === true,
+        jobId: jobId ?? null,
+        fiscal: fiscalResponse,
+      });
+    } catch (err) {
+      const safeMsg = sanitizeForLog(err.message);
+      console.error('[print-server] Errore stampante fiscale per job', safeJobId + ':', safeMsg);
+      return res.status(500).json({ ok: false, error: `Errore stampante fiscale: ${safeMsg}` });
+    }
+  }
+
+  // ── ESC/POS jobs: build buffer and dispatch via TCP/file ───────────────────
   let buf;
   try {
     buf = buildEscPosBuffer(job);
@@ -253,9 +323,14 @@ server.listen(PORT, () => {
   } else {
     console.log(`[print-server] Stampanti configurate (${printers.length}):`);
     for (const p of printers) {
-      const conn = p.type === 'file'
-        ? `file → ${p.device}`
-        : `TCP  → ${p.host}:${p.port}`;
+      let conn;
+      if (p.type === 'file') {
+        conn = `file → ${p.device}`;
+      } else if (p.type === 'fpmate') {
+        conn = `fpmate → ${p.https ? 'https' : 'http'}://${p.host}${p.port ? ':' + p.port : ''}`;
+      } else {
+        conn = `TCP  → ${p.host}:${p.port}`;
+      }
       console.log(`[print-server]   [${p.id}] ${p.name}  (${conn})`);
     }
   }

--- a/print-server/server.js
+++ b/print-server/server.js
@@ -14,9 +14,14 @@
  *   ESC/POS (stampanti termiche tcp/file): 'order', 'table_move', 'pre_bill'
  *   Fiscali (stampante Epson RT tipo fpmate):
  *     'fiscal_receipt'  – scontrino fiscale (documento commerciale)
+ *     'fiscal_refund'   – documento di reso commerciale (RESO MERCE)
+ *     'fiscal_void'     – documento di annullo commerciale (VOID)
  *     'fiscal_z_report' – chiusura giornaliera (Z report)
  *     'fiscal_x_report' – report finanziario (X report)
  *     'fiscal_status'   – query stato stampante
+ *     'fiscal_duplicate'– ristampa ultimo scontrino (documento di gestione)
+ *     'fiscal_drawer'   – apertura cassetto contanti
+ *     'fiscal_cash'     – versamento/prelievo cassa fiscale (cash in/out)
  *
  * Le stampanti fisiche sono configurate in `printers.config.js` (Opzione A) oppure
  * tramite variabili d'ambiente `PRINTER_<N>_*` (Opzione B — le env vars hanno la precedenza).
@@ -88,10 +93,10 @@ const CORS_ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || '')
   .filter(Boolean);
 
 // Supported printType values
-const VALID_PRINT_TYPES = new Set(['order', 'table_move', 'pre_bill', 'fiscal_receipt', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status']);
+const VALID_PRINT_TYPES = new Set(['order', 'table_move', 'pre_bill', 'fiscal_receipt', 'fiscal_refund', 'fiscal_void', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status', 'fiscal_duplicate', 'fiscal_drawer', 'fiscal_cash']);
 
 // Fiscal print types — dispatched via fpmate HTTP/SOAP instead of raw ESC/POS.
-const FISCAL_PRINT_TYPES = new Set(['fiscal_receipt', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status']);
+const FISCAL_PRINT_TYPES = new Set(['fiscal_receipt', 'fiscal_refund', 'fiscal_void', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status', 'fiscal_duplicate', 'fiscal_drawer', 'fiscal_cash']);
 
 // ── App Express ───────────────────────────────────────────────────────────────
 

--- a/print-server/server.js
+++ b/print-server/server.js
@@ -266,6 +266,17 @@ app.post('/print', apiKeyGuard, async (req, res) => {
   }
 
   // ── ESC/POS jobs: build buffer and dispatch via TCP/file ───────────────────
+  // ESC/POS must never be routed to an fpmate fiscal printer: _dispatch() would
+  // treat the ESC/POS buffer as fiscal XML and send an invalid payload to the
+  // RT printer. Fail fast with a clear error instead (mirrors the fiscal-side
+  // guard that rejects non-fpmate printers above).
+  if ((printerConfig.type || '').toLowerCase() === 'fpmate') {
+    return res.status(400).json({
+      ok: false,
+      error: `Il printType "${printType}" richiede una stampante ESC/POS (tcp/file), ma la stampante "${printerConfig.id}" è type="fpmate" (fiscale).`,
+    });
+  }
+
   let buf;
   try {
     buf = buildEscPosBuffer(job);

--- a/src/components/CassaBillCard.vue
+++ b/src/components/CassaBillCard.vue
@@ -347,10 +347,12 @@ function emitFiscale() {
   };
   orderStore.addFiscalReceipt(entry);
 
-  // Emit through the print-server when a fiscal printer is configured.
-  const fiscalPrinter = resolveFiscalPrinter();
+  // Emit through the print-server when a fiscal printer is configured at
+  // runtime (Directus/IDB hydrated config), passing the resolved printer id so
+  // the dispatch decision stays consistent with runtime configuration.
+  const fiscalPrinter = resolveFiscalPrinter(configStore.config.printers);
   if (fiscalPrinter) {
-    dispatchFiscalReceipt({ base, entry }).then((result) => {
+    dispatchFiscalReceipt({ base, printerId: fiscalPrinter.id, entry }).then((result) => {
       if (!result.ok) {
         console.warn('[fiscale] Emissione scontrino non riuscita:', result.error);
       }

--- a/src/components/CassaBillCard.vue
+++ b/src/components/CassaBillCard.vue
@@ -240,7 +240,8 @@
 import { ref, computed } from 'vue';
 import { ChevronDown, CreditCard, ClipboardList, Banknote, Tag, Wallet, CheckCircle, Printer, FileText } from 'lucide-vue-next';
 import { useConfigStore, useOrderStore } from '../store/index.js';
-import { billKey, getOrderItemRowTotal, buildFiscalXmlRequest, formatOrderIdShort } from '../utils/index.js';
+import { billKey, getOrderItemRowTotal, buildFiscalXmlRequest, resolveFiscalPrinter, formatOrderIdShort } from '../utils/index.js';
+import { dispatchFiscalReceipt } from '../composables/useFiscalPrint.js';
 import { newUUIDv7 } from '../store/storeUtils.js';
 import { resolveTransactionPaymentLabel } from '../utils/paymentMethods.js';
 import NumericInput from './NumericInput.vue';
@@ -345,6 +346,16 @@ function emitFiscale() {
     timestamp: new Date().toISOString(),
   };
   orderStore.addFiscalReceipt(entry);
+
+  // Emit through the print-server when a fiscal printer is configured.
+  const fiscalPrinter = resolveFiscalPrinter();
+  if (fiscalPrinter) {
+    dispatchFiscalReceipt({ base, entry }).then((result) => {
+      if (!result.ok) {
+        console.warn('[fiscale] Emissione scontrino non riuscita:', result.error);
+      }
+    });
+  }
 }
 
 function openInvoiceModal() {

--- a/src/components/CassaBillCard.vue
+++ b/src/components/CassaBillCard.vue
@@ -240,7 +240,7 @@
 import { ref, computed } from 'vue';
 import { ChevronDown, CreditCard, ClipboardList, Banknote, Tag, Wallet, CheckCircle, Printer, FileText } from 'lucide-vue-next';
 import { useConfigStore, useOrderStore } from '../store/index.js';
-import { billKey, getOrderItemRowTotal, buildFiscalXmlRequest, resolveFiscalPrinter, formatOrderIdShort } from '../utils/index.js';
+import { billKey, getOrderItemRowTotal, resolveFiscalPrinter, formatOrderIdShort } from '../utils/index.js';
 import { dispatchFiscalReceipt } from '../composables/useFiscalPrint.js';
 import { newUUIDv7 } from '../store/storeUtils.js';
 import { resolveTransactionPaymentLabel } from '../utils/paymentMethods.js';
@@ -336,11 +336,13 @@ function _buildBillSummaryBase() {
 function emitFiscale() {
   if (alreadyFiscalized.value || fiscalInvoiceDisabledForZero.value) return;
   const base = _buildBillSummaryBase();
-  const xmlRequest = buildFiscalXmlRequest(base);
+  // The fiscal XML is built server-side by the print-server (single source of
+  // truth). Don't persist a client-built xmlRequest: it would differ from the
+  // payload actually sent and produce a misleading audit record.
   const entry = {
     id: newUUIDv7(),
     ...base,
-    xmlRequest,
+    xmlRequest: null,
     xmlResponse: null,
     status: 'pending',
     timestamp: new Date().toISOString(),

--- a/src/components/CassaDashboard.vue
+++ b/src/components/CassaDashboard.vue
@@ -674,10 +674,19 @@ async function execFiscalVoid() {
   const target = voidableReceipts.value.find((r) => r.id === voidSelection.value);
   if (!target) { setFiscalMessage(false, 'Selezionare uno scontrino da annullare.'); return; }
   if (!confirm(`Confermi l'annullo fiscale dello scontrino #${target.fiscalReceiptNumber} (€${Number(target.totalAmount).toFixed(2)})? Operazione irreversibile.`)) return;
+  // fiscalReceiptDate is "dd/mm/yyyy"; fall back to the ISO basic datetime
+  // (YYYYMMDDTHHMMSS) only by converting it to "dd/mm/yyyy" so the server-side
+  // formatter receives a date it can normalize to ddmmyyyy (not raw YYYYMMDD,
+  // which would be misread as ddmmyyyy with the year first).
+  const isoFallback = (() => {
+    const iso = target.receiptISODateTime ?? '';
+    const m = /^(\d{4})(\d{2})(\d{2})/.exec(iso);
+    return m ? `${m[3]}/${m[2]}/${m[1]}` : '';
+  })();
   const receiptRef = {
     zRepNumber: target.zRepNumber ?? target.fiscalZRepNumber ?? '',
     fiscalReceiptNumber: target.fiscalReceiptNumber,
-    date: target.fiscalReceiptDate ?? (target.receiptISODateTime?.slice(0, 8) ?? ''),
+    date: target.fiscalReceiptDate ?? isoFallback,
     serialNumber: target.serialNumber ?? '',
   };
   return runFiscal(

--- a/src/components/CassaDashboard.vue
+++ b/src/components/CassaDashboard.vue
@@ -690,9 +690,17 @@ async function execFiscalVoid() {
     date: target.fiscalReceiptDate ?? isoFallback,
     serialNumber: target.serialNumber ?? '',
   };
-  return runFiscal(
+  const res = await runFiscal(
     () => dispatchFiscalVoid({ receiptRef }),
     `Annullo scontrino #${target.fiscalReceiptNumber} inviato alla stampante fiscale.`,
   );
+  // Mark the original receipt as voided in the store so it drops out of
+  // voidableReceipts (status !== 'void'), preventing repeated void attempts and
+  // keeping local audit state consistent with the fiscal printer.
+  if (res?.ok) {
+    orderStore.updateFiscalReceipt(target.id, { status: 'void', voidedAt: new Date().toISOString() });
+    voidSelection.value = null;
+  }
+  return res;
 }
 </script>

--- a/src/components/CassaDashboard.vue
+++ b/src/components/CassaDashboard.vue
@@ -410,9 +410,9 @@
                 <RefreshCw class="size-4" :class="fiscalBusy ? 'animate-spin' : ''" /> Interroga stato RT
               </button>
               <div v-if="fiscalStatus" class="mt-3 space-y-1.5 text-sm">
-                <div class="flex justify-between"><span class="text-gray-500">Giornata aperta</span><span class="font-bold" :class="fiscalStatus.rtDailyOpen === '1' ? 'text-emerald-600' : 'text-red-600'">{{ fiscalStatus.rtDailyOpen === '1' ? 'Sì' : 'No' }}</span></div>
-                <div class="flex justify-between"><span class="text-gray-500">Z necessario</span><span class="font-bold" :class="fiscalStatus.rtNoWorkingPeriod === '1' ? 'text-amber-600' : 'text-gray-700'">{{ fiscalStatus.rtNoWorkingPeriod === '1' ? 'Sì' : 'No' }}</span></div>
-                <div class="flex justify-between"><span class="text-gray-500">File da inviare</span><span class="font-bold" :class="Number(fiscalStatus.rtFileToSend) > 0 ? 'text-amber-600' : 'text-gray-700'">{{ fiscalStatus.rtFileToSend ?? '0' }}</span></div>
+                <div class="flex justify-between"><span class="text-gray-500">Giornata aperta</span><span class="font-bold" :class="rtFlag(fiscalStatus.rtDailyOpen, 'text-emerald-600', 'text-red-600').cls">{{ rtFlag(fiscalStatus.rtDailyOpen, 'text-emerald-600', 'text-red-600').text }}</span></div>
+                <div class="flex justify-between"><span class="text-gray-500">Z necessario</span><span class="font-bold" :class="rtFlag(fiscalStatus.rtNoWorkingPeriod, 'text-amber-600', 'text-gray-700').cls">{{ rtFlag(fiscalStatus.rtNoWorkingPeriod, 'text-amber-600', 'text-gray-700').text }}</span></div>
+                <div class="flex justify-between"><span class="text-gray-500">File da inviare</span><span class="font-bold" :class="rtCount(fiscalStatus.rtFileToSend, 'text-amber-600', 'text-gray-700').cls">{{ rtCount(fiscalStatus.rtFileToSend, 'text-amber-600', 'text-gray-700').text }}</span></div>
                 <div v-if="Number(fiscalStatus.rtFileRejected) > 0" class="flex justify-between"><span class="text-gray-500">File rifiutati</span><span class="font-bold text-red-600">{{ fiscalStatus.rtFileRejected }}</span></div>
                 <div class="flex justify-between"><span class="text-gray-500">Stato principale</span><span class="font-bold text-gray-700">{{ fiscalStatus.rtMainStatus ?? '–' }}</span></div>
                 <div class="flex justify-between"><span class="text-gray-500">Matricola</span><span class="font-bold text-gray-700">{{ fiscalStatus.serialNumber ?? '–' }}</span></div>
@@ -598,6 +598,20 @@ const cashDir = ref('in');
 const cashAmountInput = ref(0);
 const cashAmount = computed(() => parseFloat(cashAmountInput.value) || 0);
 const voidSelection = ref('');
+
+// I campi RT-specific (rtDailyOpen, rtNoWorkingPeriod, rtFileToSend, ...) possono
+// essere assenti se la risposta fpmate non li include (firmware non-RT, fallimento
+// parziale della richiesta). In quel caso "sconosciuto" non deve essere letto come
+// "No": mostriamo un placeholder neutro ("–") in grigio chiaro.
+function rtFlag(value, yesCls, noCls) {
+  if (value == null || value === '') return { text: '–', cls: 'text-gray-400' };
+  if (value === '1') return { text: 'Sì', cls: yesCls };
+  return { text: 'No', cls: noCls };
+}
+function rtCount(value, positiveCls, zeroCls) {
+  if (value == null || value === '') return { text: '–', cls: 'text-gray-400' };
+  return { text: String(value), cls: Number(value) > 0 ? positiveCls : zeroCls };
+}
 
 // Scontrini fiscali emessi con numero scontrino → candidati all'annullo (VOID).
 // orderStore.fiscalReceipts is auto-unwrapped by Pinia to the array value.

--- a/src/components/CassaDashboard.vue
+++ b/src/components/CassaDashboard.vue
@@ -600,8 +600,9 @@ const cashAmount = computed(() => parseFloat(cashAmountInput.value) || 0);
 const voidSelection = ref('');
 
 // Scontrini fiscali emessi con numero scontrino → candidati all'annullo (VOID).
+// orderStore.fiscalReceipts is auto-unwrapped by Pinia to the array value.
 const voidableReceipts = computed(() => {
-  const list = orderStore.fiscalReceipts ?? [];
+  const list = orderStore?.fiscalReceipts ?? [];
   return list.filter((r) => r && r.fiscalReceiptNumber && r.status !== 'void')
     .slice().reverse();
 });

--- a/src/components/CassaDashboard.vue
+++ b/src/components/CassaDashboard.vue
@@ -699,7 +699,7 @@ async function execFiscalVoid() {
   // keeping local audit state consistent with the fiscal printer.
   if (res?.ok) {
     orderStore.updateFiscalReceipt(target.id, { status: 'void', voidedAt: new Date().toISOString() });
-    voidSelection.value = null;
+    voidSelection.value = '';
   }
   return res;
 }

--- a/src/components/CassaDashboard.vue
+++ b/src/components/CassaDashboard.vue
@@ -263,6 +263,13 @@
             class="w-full py-4 theme-bg text-white rounded-2xl font-bold shadow-md hover:opacity-90 transition-opacity active:scale-95 flex items-center justify-center gap-2 text-sm md:text-base">
             <RefreshCw class="size-5" /> Aggiorna Lettura X
           </button>
+
+          <!-- Stampa X fiscale RT -->
+          <button v-if="hasFiscalPrinter" @click="printFiscalX"
+            :disabled="fiscalBusy"
+            class="w-full py-3 bg-amber-600 hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-2xl font-bold shadow-md transition-colors active:scale-95 flex items-center justify-center gap-2 text-sm">
+            <Printer class="size-5" /> Stampa Lettura X Fiscale (stampante RT)
+          </button>
         </div>
 
         <!-- TAB: LETTURA Z (CHIUSURA) -->
@@ -359,10 +366,119 @@
             <Eye class="size-5" /> Anteprima Chiusura
           </button>
 
+          <!-- Stampa Z fiscale RT (prima della chiusura locale) -->
+          <button v-if="hasFiscalPrinter && isAdmin" @click="printFiscalZ"
+            :disabled="fiscalBusy"
+            class="w-full py-3 bg-orange-600 hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-2xl font-bold shadow-md transition-colors active:scale-95 flex items-center justify-center gap-2 text-sm">
+            <Printer class="size-5" /> Stampa Lettura Z Fiscale (stampante RT)
+          </button>
+
           <button v-if="isAdmin" @click="confirmDailyClose"
             class="w-full py-4 bg-red-600 hover:bg-red-700 text-white rounded-2xl font-bold shadow-md transition-colors active:scale-95 flex items-center justify-center gap-2 text-sm md:text-base">
             <Lock class="size-5" /> Esegui Lettura Z (Chiudi Giornata)
           </button>
+        </div>
+
+        <!-- TAB: STAMPANTE FISCALE RT -->
+        <div v-if="activeTab === 'fiscal'" class="space-y-4">
+
+          <div v-if="!hasFiscalPrinter" class="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800 flex items-start gap-2">
+            <Info class="size-5 shrink-0 mt-0.5" />
+            <div>
+              <p class="font-bold">Nessuna stampante fiscale RT configurata.</p>
+              <p class="text-xs mt-1">Configurare una stampante di tipo <code>fpmate</code> nelle impostazioni per abilitare le operazioni fiscali.</p>
+            </div>
+          </div>
+
+          <template v-else>
+
+            <!-- Stato operazione -->
+            <div v-if="fiscalMessage" class="rounded-xl p-3 flex items-start gap-2 text-sm"
+              :class="fiscalMessage.ok ? 'bg-emerald-50 border border-emerald-200 text-emerald-800' : 'bg-red-50 border border-red-200 text-red-800'">
+              <component :is="fiscalMessage.ok ? CheckCircle2 : XCircle" class="size-5 shrink-0 mt-0.5" />
+              <p class="font-medium whitespace-pre-line">{{ fiscalMessage.text }}</p>
+            </div>
+
+            <!-- Stato stampante -->
+            <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-4 md:p-5">
+              <h4 class="font-bold text-gray-700 text-sm uppercase tracking-wider mb-3 flex items-center gap-2">
+                <Info class="size-4 text-blue-600" /> Stato Stampante
+              </h4>
+              <button @click="queryFiscalStatus('1')"
+                :disabled="fiscalBusy"
+                class="w-full py-2.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-xl font-bold text-sm flex items-center justify-center gap-2 active:scale-95 transition-all">
+                <RefreshCw class="size-4" :class="fiscalBusy ? 'animate-spin' : ''" /> Interroga stato RT
+              </button>
+              <div v-if="fiscalStatus" class="mt-3 space-y-1.5 text-sm">
+                <div class="flex justify-between"><span class="text-gray-500">Giornata aperta</span><span class="font-bold" :class="fiscalStatus.rtDailyOpen === '1' ? 'text-emerald-600' : 'text-red-600'">{{ fiscalStatus.rtDailyOpen === '1' ? 'Sì' : 'No' }}</span></div>
+                <div class="flex justify-between"><span class="text-gray-500">Z necessario</span><span class="font-bold" :class="fiscalStatus.rtNoWorkingPeriod === '1' ? 'text-amber-600' : 'text-gray-700'">{{ fiscalStatus.rtNoWorkingPeriod === '1' ? 'Sì' : 'No' }}</span></div>
+                <div class="flex justify-between"><span class="text-gray-500">File da inviare</span><span class="font-bold" :class="Number(fiscalStatus.rtFileToSend) > 0 ? 'text-amber-600' : 'text-gray-700'">{{ fiscalStatus.rtFileToSend ?? '0' }}</span></div>
+                <div v-if="Number(fiscalStatus.rtFileRejected) > 0" class="flex justify-between"><span class="text-gray-500">File rifiutati</span><span class="font-bold text-red-600">{{ fiscalStatus.rtFileRejected }}</span></div>
+                <div class="flex justify-between"><span class="text-gray-500">Stato principale</span><span class="font-bold text-gray-700">{{ fiscalStatus.rtMainStatus ?? '–' }}</span></div>
+                <div class="flex justify-between"><span class="text-gray-500">Matricola</span><span class="font-bold text-gray-700">{{ fiscalStatus.serialNumber ?? '–' }}</span></div>
+                <div v-if="fiscalStatus.rtExpiryCD" class="flex justify-between"><span class="text-gray-500">Scadenza certificato</span><span class="font-bold text-gray-700">{{ fiscalStatus.rtExpiryCD }}</span></div>
+              </div>
+            </div>
+
+            <!-- Operazioni rapide -->
+            <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-4 md:p-5">
+              <h4 class="font-bold text-gray-700 text-sm uppercase tracking-wider mb-3 flex items-center gap-2">
+                <Coins class="size-4 text-emerald-600" /> Operazioni Rapide
+              </h4>
+              <div class="grid grid-cols-2 gap-2">
+                <button @click="openDrawer" :disabled="fiscalBusy"
+                  class="py-2.5 bg-gray-700 hover:bg-gray-800 disabled:opacity-50 text-white rounded-xl font-bold text-sm flex items-center justify-center gap-2 active:scale-95 transition-all">
+                  <Coins class="size-4" /> Apri Cassetto
+                </button>
+                <button @click="printDuplicate" :disabled="fiscalBusy"
+                  class="py-2.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-xl font-bold text-sm flex items-center justify-center gap-2 active:scale-95 transition-all">
+                  <Copy class="size-4" /> Duplicato Scontrino
+                </button>
+              </div>
+            </div>
+
+            <!-- Movimento cassa fiscale -->
+            <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-4 md:p-5">
+              <h4 class="font-bold text-gray-700 text-sm uppercase tracking-wider mb-3 flex items-center gap-2">
+                <ArrowLeftRight class="size-4 text-purple-600" /> Movimento Cassa Fiscale
+              </h4>
+              <p class="text-xs text-gray-400 mb-3">Versamento o prelievo registrato nella memoria fiscale della stampante RT.</p>
+              <div class="space-y-3">
+                <div class="flex gap-2">
+                  <button @click="cashDir = 'in'" :class="cashDir === 'in' ? 'bg-emerald-600 text-white' : 'bg-gray-100 text-gray-600'" class="flex-1 py-2.5 rounded-xl font-bold text-sm transition-all">Versamento</button>
+                  <button @click="cashDir = 'out'" :class="cashDir === 'out' ? 'bg-red-600 text-white' : 'bg-gray-100 text-gray-600'" class="flex-1 py-2.5 rounded-xl font-bold text-sm transition-all">Prelievo</button>
+                </div>
+                <NumericInput v-model="cashAmountInput" min="0" step="1" :prefix="configStore.config.ui.currency"
+                  class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl font-black text-xl text-gray-800 focus:border-[var(--brand-primary)] focus:outline-none" placeholder="0.00" />
+                <button @click="execFiscalCash" :disabled="fiscalBusy || !cashAmount"
+                  class="w-full py-3 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white rounded-xl font-bold text-sm flex items-center justify-center gap-2 active:scale-95 transition-all">
+                  <ArrowLeftRight class="size-4" /> Conferma {{ cashDir === 'in' ? 'Versamento' : 'Prelievo' }}
+                </button>
+              </div>
+            </div>
+
+            <!-- Annullo scontrino (VOID) -->
+            <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-4 md:p-5">
+              <h4 class="font-bold text-gray-700 text-sm uppercase tracking-wider mb-3 flex items-center gap-2">
+                <RotateCcw class="size-4 text-red-600" /> Annullo Scontrino (Void)
+              </h4>
+              <p class="text-xs text-gray-400 mb-3">Seleziona uno scontrino emesso oggi per emettere il documento di annullo fiscale. Operazione irreversibile.</p>
+              <div v-if="voidableReceipts.length === 0" class="text-sm text-gray-400 italic py-2">Nessuno scontrino fiscale emesso disponibile.</div>
+              <template v-else>
+                <select v-model="voidSelection" class="w-full px-3 py-2.5 border-2 border-gray-200 rounded-xl text-sm font-bold text-gray-700 focus:border-[var(--brand-primary)] focus:outline-none mb-3">
+                  <option value="">Seleziona scontrino…</option>
+                  <option v-for="r in voidableReceipts" :key="r.id" :value="r.id">
+                    #{{ r.fiscalReceiptNumber }} · {{ r.tableLabel || r.table }} · €{{ Number(r.totalAmount).toFixed(2) }} · {{ r.fiscalReceiptDate }}
+                  </option>
+                </select>
+                <button @click="execFiscalVoid" :disabled="fiscalBusy || !voidSelection"
+                  class="w-full py-3 bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white rounded-xl font-bold text-sm flex items-center justify-center gap-2 active:scale-95 transition-all">
+                  <RotateCcw class="size-4" /> Emetti Annullo
+                </button>
+              </template>
+            </div>
+
+          </template>
         </div>
 
       </div>
@@ -375,12 +491,18 @@ import { ref, computed, watch } from 'vue';
 import {
   X, Landmark, Wallet, ArrowLeftRight, ArrowDownCircle, ArrowUpCircle, Plus,
   Eye, AlertTriangle, Lock, RefreshCw, Save, TrendingUp, CreditCard, Users,
-  Receipt, History, ClipboardList, Tag, Gift, FileText,
+  Receipt, History, ClipboardList, Tag, Gift, FileText, Printer, Copy, RotateCcw,
+  Coins, Info, CheckCircle2, XCircle,
 } from 'lucide-vue-next';
 import { Banknote } from 'lucide-vue-next';
 import { useConfigStore, useOrderStore } from '../store/index.js';
 import { useAuth } from '../composables/useAuth.js';
 import NumericInput from './NumericInput.vue';
+import {
+  dispatchFiscalZReport, dispatchFiscalXReport, dispatchFiscalStatus,
+  dispatchFiscalDuplicate, dispatchFiscalOpenDrawer, dispatchFiscalCash,
+  dispatchFiscalVoid, resolveFiscalPrinter,
+} from '../composables/useFiscalPrint.js';
 
 defineProps({ modelValue: Boolean });
 defineEmits(['update:modelValue']);
@@ -395,6 +517,7 @@ const tabs = [
   { id: 'cashBalance', label: 'Fondo Cassa', icon: Wallet },
   { id: 'xReport', label: 'Lettura X', icon: Eye },
   { id: 'zReport', label: 'Lettura Z', icon: Lock },
+  { id: 'fiscal', label: 'Fiscale RT', icon: Printer },
 ];
 
 const activeTab = ref('cashBalance');
@@ -465,4 +588,101 @@ const xHasClosureTypeData = computed(() =>
 const zHasClosureTypeData = computed(() =>
   zPreview.value != null && (zPreview.value.fiscalCount > 0 || zPreview.value.invoiceCount > 0),
 );
+
+// ── Stampante fiscale RT ─────────────────────────────────────────────────────
+const hasFiscalPrinter = computed(() => resolveFiscalPrinter() != null);
+const fiscalBusy = ref(false);
+const fiscalMessage = ref(null); // { ok: boolean, text: string }
+const fiscalStatus = ref(null);  // addInfo mappa dalla risposta queryPrinterStatus RT
+const cashDir = ref('in');
+const cashAmountInput = ref(0);
+const cashAmount = computed(() => parseFloat(cashAmountInput.value) || 0);
+const voidSelection = ref('');
+
+// Scontrini fiscali emessi con numero scontrino → candidati all'annullo (VOID).
+const voidableReceipts = computed(() => {
+  const list = orderStore.fiscalReceipts ?? [];
+  return list.filter((r) => r && r.fiscalReceiptNumber && r.status !== 'void')
+    .slice().reverse();
+});
+
+function setFiscalMessage(ok, text) {
+  fiscalMessage.value = { ok, text };
+}
+
+async function runFiscal(fn, successMsg) {
+  if (fiscalBusy.value) return;
+  fiscalBusy.value = true;
+  fiscalMessage.value = null;
+  try {
+    const res = await fn();
+    if (res.ok) {
+      setFiscalMessage(true, successMsg);
+    } else {
+      setFiscalMessage(false, res.error || 'Operazione non riuscita.');
+    }
+    return res;
+  } catch (err) {
+    setFiscalMessage(false, err?.message ?? String(err));
+    return { ok: false, error: err?.message };
+  } finally {
+    fiscalBusy.value = false;
+  }
+}
+
+async function printFiscalX() {
+  return runFiscal(() => dispatchFiscalXReport(), 'Lettura X fiscale inviata alla stampante RT.');
+}
+
+async function printFiscalZ() {
+  if (!confirm('Confermi la stampa della Lettura Z fiscale? Trasmette i dati all\'Agenzia delle Entrate e chiude la giornata fiscale.')) return;
+  return runFiscal(() => dispatchFiscalZReport(), 'Lettura Z fiscale inviata. Chiusura fiscale in corso sulla stampante RT.');
+}
+
+async function queryFiscalStatus(statusType = '1') {
+  return runFiscal(async () => {
+    const res = await dispatchFiscalStatus({ statusType });
+    if (res.ok) {
+      const addInfo = res.fiscal?.addInfo ?? {};
+      fiscalStatus.value = addInfo;
+      return { ok: true };
+    }
+    fiscalStatus.value = null;
+    return res;
+  }, 'Stato stampante interrogato.');
+}
+
+async function openDrawer() {
+  return runFiscal(() => dispatchFiscalOpenDrawer(), 'Apertura cassetto inviata alla stampante fiscale.');
+}
+
+async function printDuplicate() {
+  return runFiscal(() => dispatchFiscalDuplicate(), 'Duplicato ultimo scontrino inviato alla stampante fiscale.');
+}
+
+async function execFiscalCash() {
+  if (cashAmount.value <= 0) { setFiscalMessage(false, 'Inserire un importo valido.'); return; }
+  const verb = cashDir.value === 'in' ? 'versamento di' : 'prelievo di';
+  if (!confirm(`Confermi il ${verb} €${cashAmount.value.toFixed(2)} sulla stampante fiscale?`)) return;
+  return runFiscal(
+    () => dispatchFiscalCash({ direction: cashDir.value, amount: cashAmount.value }),
+    `${cashDir.value === 'in' ? 'Versamento' : 'Prelievo'} di €${cashAmount.value.toFixed(2)} registrato sulla stampante fiscale.`,
+  );
+}
+
+async function execFiscalVoid() {
+  const target = voidableReceipts.value.find((r) => r.id === voidSelection.value);
+  if (!target) { setFiscalMessage(false, 'Selezionare uno scontrino da annullare.'); return; }
+  if (!confirm(`Confermi l'annullo fiscale dello scontrino #${target.fiscalReceiptNumber} (€${Number(target.totalAmount).toFixed(2)})? Operazione irreversibile.`)) return;
+  const receiptRef = {
+    zRepNumber: target.zRepNumber ?? target.fiscalZRepNumber ?? '',
+    fiscalReceiptNumber: target.fiscalReceiptNumber,
+    date: target.fiscalReceiptDate ?? (target.receiptISODateTime?.slice(0, 8) ?? ''),
+    serialNumber: target.serialNumber ?? '',
+  };
+  return runFiscal(
+    () => dispatchFiscalVoid({ receiptRef }),
+    `Annullo scontrino #${target.fiscalReceiptNumber} inviato alla stampante fiscale.`,
+  );
+}
 </script>

--- a/src/components/CassaTableManager.vue
+++ b/src/components/CassaTableManager.vue
@@ -1390,7 +1390,8 @@ import {
 } from 'lucide-vue-next';
 import { useConfigStore, useOrderStore } from '../store/index.js';
 import { newUUIDv7, newShortId } from '../store/storeUtils.js';
-import { getOrderItemRowTotal, KITCHEN_ACTIVE_STATUSES, getLockedDirectItems, buildFiscalXmlRequest, formatOrderTime, formatOrderIdShort } from '../utils/index.js';
+import { getOrderItemRowTotal, KITCHEN_ACTIVE_STATUSES, getLockedDirectItems, buildFiscalXmlRequest, resolveFiscalPrinter, formatOrderTime, formatOrderIdShort } from '../utils/index.js';
+import { dispatchFiscalReceipt } from '../composables/useFiscalPrint.js';
 import { buildFlatAnaliticaItems, computeAnaliticaTotal, exceedsAmount, getOrdersToComplete } from '../utils/analitica.js';
 import { loadCustomItemsFromIDB, saveCustomItemsToIDB } from '../store/persistence/settings.js';
 import { resolveTransactionPaymentLabel } from '../utils/paymentMethods.js';
@@ -2658,6 +2659,19 @@ async function closeTableBillFiscale() {
   }
   orderStore.addFiscalReceipt(entry);
   closeTableModal();
+
+  // Emit the fiscal receipt through the print-server when a fiscal printer is
+  // configured. The XML is built server-side (fonte unica); the browser sends
+  // only the structured job. On success the entry is updated with the receipt
+  // number returned by the fiscal printer; on failure the error is surfaced.
+  const fiscalPrinter = resolveFiscalPrinter();
+  if (fiscalPrinter) {
+    const result = await dispatchFiscalReceipt({ base, entry });
+    if (!result.ok) {
+      console.warn('[fiscale] Emissione scontrino non riuscita:', result.error);
+      // The pending entry above remains visible in the bill history for retry.
+    }
+  }
 }
 
 async function confirmInvoice(billingData) {

--- a/src/components/CassaTableManager.vue
+++ b/src/components/CassaTableManager.vue
@@ -1390,7 +1390,7 @@ import {
 } from 'lucide-vue-next';
 import { useConfigStore, useOrderStore } from '../store/index.js';
 import { newUUIDv7, newShortId } from '../store/storeUtils.js';
-import { getOrderItemRowTotal, KITCHEN_ACTIVE_STATUSES, getLockedDirectItems, buildFiscalXmlRequest, resolveFiscalPrinter, formatOrderTime, formatOrderIdShort } from '../utils/index.js';
+import { getOrderItemRowTotal, KITCHEN_ACTIVE_STATUSES, getLockedDirectItems, resolveFiscalPrinter, formatOrderTime, formatOrderIdShort } from '../utils/index.js';
 import { dispatchFiscalReceipt } from '../composables/useFiscalPrint.js';
 import { buildFlatAnaliticaItems, computeAnaliticaTotal, exceedsAmount, getOrdersToComplete } from '../utils/analitica.js';
 import { loadCustomItemsFromIDB, saveCustomItemsToIDB } from '../store/persistence/settings.js';
@@ -2645,11 +2645,14 @@ async function closeTableBillFiscale() {
   if (isZeroAmountBill.value) return;
   const base = _buildBillSummaryBase();
   if (!base) return;
-  const xmlRequest = buildFiscalXmlRequest(base);
+  // The fiscal XML is built server-side by the print-server (single source of
+  // truth). Don't persist a client-built xmlRequest here: it would differ from
+  // the payload actually sent and produce a misleading audit record. Leave
+  // xmlRequest null until the server-generated XML is persisted back.
   const entry = {
     id: newUUIDv7(),
     ...base,
-    xmlRequest,
+    xmlRequest: null,
     xmlResponse: null,
     status: 'pending',
     timestamp: base.closedAt,
@@ -2661,12 +2664,10 @@ async function closeTableBillFiscale() {
   closeTableModal();
 
   // Emit the fiscal receipt through the print-server when a fiscal printer is
-  // configured at runtime (Directus/IDB hydrated config). The XML is built
-  // server-side (fonte unica); the browser sends only the structured job and
-  // the resolved printer id. The client-built `xmlRequest` above is kept only
-  // as an audit record of what was sent, not as the source of truth for
-  // emission. On success the entry is updated with the receipt number returned
-  // by the fiscal printer; on failure the error is surfaced.
+  // configured at runtime (Directus/IDB hydrated config). The browser sends
+  // only the structured job and the resolved printer id; the XML is generated
+  // server-side. On success the entry is updated with the receipt number
+  // returned by the fiscal printer; on failure the error is surfaced.
   const fiscalPrinter = resolveFiscalPrinter(configStore.config.printers);
   if (fiscalPrinter) {
     const result = await dispatchFiscalReceipt({ base, printerId: fiscalPrinter.id, entry });

--- a/src/components/CassaTableManager.vue
+++ b/src/components/CassaTableManager.vue
@@ -2661,12 +2661,15 @@ async function closeTableBillFiscale() {
   closeTableModal();
 
   // Emit the fiscal receipt through the print-server when a fiscal printer is
-  // configured. The XML is built server-side (fonte unica); the browser sends
-  // only the structured job. On success the entry is updated with the receipt
-  // number returned by the fiscal printer; on failure the error is surfaced.
-  const fiscalPrinter = resolveFiscalPrinter();
+  // configured at runtime (Directus/IDB hydrated config). The XML is built
+  // server-side (fonte unica); the browser sends only the structured job and
+  // the resolved printer id. The client-built `xmlRequest` above is kept only
+  // as an audit record of what was sent, not as the source of truth for
+  // emission. On success the entry is updated with the receipt number returned
+  // by the fiscal printer; on failure the error is surfaced.
+  const fiscalPrinter = resolveFiscalPrinter(configStore.config.printers);
   if (fiscalPrinter) {
-    const result = await dispatchFiscalReceipt({ base, entry });
+    const result = await dispatchFiscalReceipt({ base, printerId: fiscalPrinter.id, entry });
     if (!result.ok) {
       console.warn('[fiscale] Emissione scontrino non riuscita:', result.error);
       // The pending entry above remains visible in the bill history for retry.

--- a/src/components/__tests__/CassaDashboard.void.test.js
+++ b/src/components/__tests__/CassaDashboard.void.test.js
@@ -139,6 +139,9 @@ describe('CassaDashboard — fiscal VOID marks original receipt as voided', () =
     const updated = orderStore.fiscalReceipts.find((r) => r.id === 'fr-1');
     expect(updated.status).toBe('void');
     expect(updated.voidedAt).toBeTruthy();
+    // After voiding, the receipt drops out of voidableReceipts (status === 'void'),
+    // so the selection UI collapses back to the empty-state message.
+    expect(wrapper.text()).toContain('Nessuno scontrino');
   });
 
   it('does NOT mark the receipt voided when the void dispatch fails', async () => {

--- a/src/components/__tests__/CassaDashboard.void.test.js
+++ b/src/components/__tests__/CassaDashboard.void.test.js
@@ -1,0 +1,166 @@
+/**
+ * @file __tests__/CassaDashboard.void.test.js
+ * @description Focused tests for the fiscal VOID flow in CassaDashboard:
+ * after a successful void dispatch the original fiscalReceipts entry must be
+ * marked as voided in the store (status 'void') so it drops out of
+ * voidableReceipts, preventing repeated void attempts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+// Mock useFiscalPrint so we can drive dispatchFiscalVoid to ok/err without
+// touching the network, and force resolveFiscalPrinter to return a configured
+// printer so the fiscal tab + VOID UI render.
+const dispatchFiscalVoidMock = vi.fn();
+vi.mock('../../composables/useFiscalPrint.js', () => ({
+  dispatchFiscalZReport: vi.fn(),
+  dispatchFiscalXReport: vi.fn(),
+  dispatchFiscalStatus: vi.fn(),
+  dispatchFiscalDuplicate: vi.fn(),
+  dispatchFiscalOpenDrawer: vi.fn(),
+  dispatchFiscalCash: vi.fn(),
+  dispatchFiscalVoid: (...args) => dispatchFiscalVoidMock(...args),
+  resolveFiscalPrinter: () => ({ id: 'fiscale', name: 'Epson RT', type: 'fpmate', url: 'http://localhost:3001' }),
+}));
+
+// Mock useAuth so isAdmin is true (the fiscal tab is admin-gated in places).
+vi.mock('../../composables/useAuth.js', () => ({
+  useAuth: () => ({ isAdmin: true, currentUser: { id: 'u1', name: 'Op' } }),
+}));
+
+// Mock the IDB persistence layer so the store's auto-hydration resolves
+// instantly with an empty array instead of racing fake-indexeddb cursors.
+// We only need the fiscal-receipt load/save stubs; the rest are no-ops.
+vi.mock('../../store/persistence/audit.js', async () => {
+  const actual = await vi.importActual('../../store/persistence/audit.js');
+  return {
+    ...actual,
+    loadFiscalReceiptsFromIDB: async () => [],
+    saveFiscalReceiptToIDB: async () => {},
+    pruneFiscalReceiptsInIDB: async () => {},
+  };
+});
+
+// Stub all lucide icons as <span /> to keep the DOM light.
+const ICONS = [
+  'X', 'Landmark', 'Wallet', 'ArrowLeftRight', 'ArrowDownCircle', 'ArrowUpCircle',
+  'Plus', 'Eye', 'AlertTriangle', 'Lock', 'RefreshCw', 'Save', 'TrendingUp',
+  'CreditCard', 'Users', 'Receipt', 'History', 'ClipboardList', 'Tag', 'Gift',
+  'FileText', 'Printer', 'Copy', 'RotateCcw', 'Coins', 'Info', 'CheckCircle2',
+  'XCircle', 'Banknote',
+];
+const ICON_STUBS = Object.fromEntries(ICONS.map((n) => [n, { template: '<span />' }]));
+const NumericInput = { template: '<input />' };
+
+enableAutoUnmount(afterEach);
+
+const VOIDABLE_RECEIPT = {
+  id: 'fr-1',
+  status: 'done',
+  fiscalReceiptNumber: '5',
+  zRepNumber: '39',
+  fiscalReceiptDate: '31/01/2024',
+  serialNumber: '99IEB004001',
+  totalAmount: 12.5,
+  tableLabel: 'Tavolo 2',
+};
+
+async function mountDashboard() {
+  const CassaDashboard = (await import('../CassaDashboard.vue')).default;
+  return mount(CassaDashboard, {
+    props: { modelValue: true },
+    global: {
+      stubs: { teleport: true, NumericInput, ...ICON_STUBS },
+    },
+  });
+}
+
+describe('CassaDashboard — fiscal VOID marks original receipt as voided', () => {
+  let orderStore;
+
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    const { useOrderStore } = await import('../../store/index.js');
+    orderStore = useOrderStore();
+    dispatchFiscalVoidMock.mockReset();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The store auto-hydrates fiscalReceipts from IDB on init; that async load
+  // overwrites fiscalReceipts with the (empty) IDB result. Keep re-seeding
+  // until hydration has completed AND the entry is still present afterwards.
+  async function seedVoidableReceipt() {
+    for (let i = 0; i < 50; i++) {
+      if (orderStore.fiscalInvoiceHydrated && orderStore.fiscalReceipts.some((r) => r.id === 'fr-1')) return;
+      if (!orderStore.fiscalReceipts.some((r) => r.id === 'fr-1')) {
+        orderStore.addFiscalReceipt({ ...VOIDABLE_RECEIPT });
+      }
+      await flushPromises();
+    }
+    throw new Error('fiscal receipt fr-1 never persisted into store');
+  }
+
+  it('marks the original receipt as void after a successful void dispatch', async () => {
+    dispatchFiscalVoidMock.mockResolvedValue({ ok: true, fiscal: { success: true } });
+    const wrapper = await mountDashboard();
+    await seedVoidableReceipt();
+
+    // Switch to the fiscal tab where the VOID UI lives.
+    const fiscalTab = wrapper.findAll('button').find((b) => b.text().includes('Fiscale RT'));
+    await fiscalTab.trigger('click');
+    await flushPromises();
+
+    // Select the voidable receipt.
+    const select = wrapper.find('select');
+    expect(select.exists()).toBe(true);
+    await select.setValue('fr-1');
+
+    // Click "Emetti Annullo".
+    const voidBtn = wrapper.findAll('button').find((b) => b.text().includes('Emetti Annullo'));
+    expect(voidBtn.exists()).toBe(true);
+    await voidBtn.trigger('click');
+    await flushPromises();
+
+    expect(dispatchFiscalVoidMock).toHaveBeenCalledTimes(1);
+    const arg = dispatchFiscalVoidMock.mock.calls[0][0];
+    expect(arg.receiptRef).toMatchObject({
+      zRepNumber: '39',
+      fiscalReceiptNumber: '5',
+      date: '31/01/2024',
+      serialNumber: '99IEB004001',
+    });
+    // The original store entry is now voided.
+    const updated = orderStore.fiscalReceipts.find((r) => r.id === 'fr-1');
+    expect(updated.status).toBe('void');
+    expect(updated.voidedAt).toBeTruthy();
+  });
+
+  it('does NOT mark the receipt voided when the void dispatch fails', async () => {
+    dispatchFiscalVoidMock.mockResolvedValue({ ok: false, error: 'Stampante offline' });
+    const wrapper = await mountDashboard();
+    await seedVoidableReceipt();
+
+    const fiscalTab = wrapper.findAll('button').find((b) => b.text().includes('Fiscale RT'));
+    await fiscalTab.trigger('click');
+    await flushPromises();
+
+    const select = wrapper.find('select');
+    expect(select.exists()).toBe(true);
+    await select.setValue('fr-1');
+
+    const voidBtn = wrapper.findAll('button').find((b) => b.text().includes('Emetti Annullo'));
+    await voidBtn.trigger('click');
+    await flushPromises();
+
+    expect(dispatchFiscalVoidMock).toHaveBeenCalledTimes(1);
+    // On failure the entry stays done and remains voidable.
+    const entry = orderStore.fiscalReceipts.find((r) => r.id === 'fr-1');
+    expect(entry.status).toBe('done');
+  });
+});

--- a/src/components/__tests__/CassaDashboard.void.test.js
+++ b/src/components/__tests__/CassaDashboard.void.test.js
@@ -14,10 +14,11 @@ import { createPinia, setActivePinia } from 'pinia';
 // touching the network, and force resolveFiscalPrinter to return a configured
 // printer so the fiscal tab + VOID UI render.
 const dispatchFiscalVoidMock = vi.fn();
+const dispatchFiscalStatusMock = vi.fn();
 vi.mock('../../composables/useFiscalPrint.js', () => ({
   dispatchFiscalZReport: vi.fn(),
   dispatchFiscalXReport: vi.fn(),
-  dispatchFiscalStatus: vi.fn(),
+  dispatchFiscalStatus: (...args) => dispatchFiscalStatusMock(...args),
   dispatchFiscalDuplicate: vi.fn(),
   dispatchFiscalOpenDrawer: vi.fn(),
   dispatchFiscalCash: vi.fn(),
@@ -165,5 +166,82 @@ describe('CassaDashboard — fiscal VOID marks original receipt as voided', () =
     // On failure the entry stays done and remains voidable.
     const entry = orderStore.fiscalReceipts.find((r) => r.id === 'fr-1');
     expect(entry.status).toBe('done');
+  });
+});
+
+// ── RT status UI: placeholder for absent fields ───────────────────────────────
+// Quando la risposta fpmate non include le chiavi RT-specific (firmware non-RT
+// o fallimento parziale), i campi assenti non devono essere letti come "No"
+// (soprattutto rtDailyOpen, dove "No" rosso indica giornata chiusa). Mostriamo
+// un placeholder neutro "–" per i campi sconosciuti.
+
+describe('CassaDashboard — RT status renders placeholder for absent fields', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    dispatchFiscalStatusMock.mockReset();
+    dispatchFiscalVoidMock.mockReset();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  async function openFiscalTab(wrapper) {
+    const fiscalTab = wrapper.findAll('button').find((b) => b.text().includes('Fiscale RT'));
+    await fiscalTab.trigger('click');
+    await flushPromises();
+  }
+
+  it('renders "–" (not "No") for absent RT-specific fields', async () => {
+    // All RT-specific keys absent: addInfo carries only unrelated fields.
+    dispatchFiscalStatusMock.mockResolvedValue({
+      ok: true,
+      fiscal: { success: true, addInfo: { serialNumber: '99IEB004001' } },
+    });
+    const wrapper = await mountDashboard();
+    await openFiscalTab(wrapper);
+
+    const statusBtn = wrapper.findAll('button').find((b) => b.text().includes('Interroga stato RT'));
+    expect(statusBtn.exists()).toBe(true);
+    await statusBtn.trigger('click');
+    await flushPromises();
+
+    const text = wrapper.text();
+    // Absent boolean flags must NOT be read as "No" (red = giornata chiusa);
+    // the neutral placeholder "–" is rendered instead.
+    expect(text).toContain('Giornata aperta');
+    expect(text).toContain('Z necessario');
+    expect(text).toContain('File da inviare');
+    // The three absent-flag rows render "–", not "No" / "0".
+    const dashCount = (text.match(/–/g) || []).length;
+    expect(dashCount).toBeGreaterThanOrEqual(3);
+    // rtDailyOpen absent must not be misread as "No": ensure the red "No" is
+    // not rendered for the giornata row. The placeholder is gray ("–").
+    expect(text).not.toMatch(/Giornata aperta.*No/);
+  });
+
+  it('renders "Sì"/"No" with colors when RT fields are present', async () => {
+    dispatchFiscalStatusMock.mockResolvedValue({
+      ok: true,
+      fiscal: {
+        success: true,
+        addInfo: {
+          rtDailyOpen: '1',
+          rtNoWorkingPeriod: '0',
+          rtFileToSend: '2',
+          serialNumber: '99IEB004001',
+        },
+      },
+    });
+    const wrapper = await mountDashboard();
+    await openFiscalTab(wrapper);
+
+    const statusBtn = wrapper.findAll('button').find((b) => b.text().includes('Interroga stato RT'));
+    await statusBtn.trigger('click');
+    await flushPromises();
+
+    const text = wrapper.text();
+    // rtDailyOpen='1' → "Sì"; rtNoWorkingPeriod='0' → "No"; rtFileToSend='2' → "2".
+    expect(text).toMatch(/Giornata aperta.*Sì/);
+    expect(text).toMatch(/Z necessario.*No/);
+    expect(text).toMatch(/File da inviare.*2/);
   });
 });

--- a/src/composables/__tests__/useFiscalPrint.test.js
+++ b/src/composables/__tests__/useFiscalPrint.test.js
@@ -1,0 +1,186 @@
+/**
+ * @file composables/__tests__/useFiscalPrint.test.js
+ * @description Unit test per il composable useFiscalPrint: dispatch di scontrino
+ * fiscale, Z report e gestione errori, con store e fetch mockati.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetIDBSingleton } from '../useIDB.js';
+import { getSyncLogs } from '../../store/persistence/syncLogs.js';
+
+// Mock the store so useAppStore returns a stub with fiscalReceipts + mutators.
+const storeStub = {
+  configHydrated: true,
+  config: {
+    printers: [
+      { id: 'demo', url: 'http://localhost:3001/print' },
+      { id: 'fiscale', connectionType: 'fpmate', url: 'http://localhost:3001/print', printTypes: ['fiscal_receipt'] },
+    ],
+  },
+  fiscalReceipts: { value: [] },
+  addFiscalReceipt: vi.fn((entry) => { storeStub.fiscalReceipts.value.unshift(entry); }),
+  updateFiscalReceipt: vi.fn((id, updates) => {
+    const idx = storeStub.fiscalReceipts.value.findIndex((e) => e.id === id);
+    if (idx !== -1) storeStub.fiscalReceipts.value[idx] = { ...storeStub.fiscalReceipts.value[idx], ...updates };
+  }),
+};
+
+vi.mock('../../store/index.js', () => ({
+  useAppStore: () => storeStub,
+}));
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(async () => {
+  await _resetIDBSingleton();
+  vi.restoreAllMocks();
+  global.fetch = vi.fn();
+  storeStub.fiscalReceipts.value = [];
+  storeStub.addFiscalReceipt.mockClear();
+  storeStub.updateFiscalReceipt.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  global.fetch = ORIGINAL_FETCH;
+});
+
+const baseBill = {
+  orders: [{ items: [{ name: 'Panino', quantity: 2, unitPrice: 6.5 }] }],
+  paymentMethods: ['Contanti'],
+  totalAmount: 13,
+};
+
+describe('dispatchFiscalReceipt', () => {
+  it('sends a fiscal_receipt job and stores the receipt number on success', async () => {
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    // Pre-populate the store with the pending entry, mirroring the real flow
+    // where the component adds the pending entry before dispatching.
+    storeStub.fiscalReceipts.value = [{ id: 'rec-1', status: 'pending', ...baseBill }];
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        ok: true,
+        fiscal: {
+          success: true, code: '', status: '2',
+          raw: '<response/>',
+          addInfo: { fiscalReceiptNumber: '5', fiscalReceiptAmount: '13,00', serialNumber: '99IEB004001' },
+        },
+      }),
+    });
+
+    const result = await dispatchFiscalReceipt({ base: baseBill, entry: { id: 'rec-1', timestamp: '2024-01-01T00:00:00Z' } });
+    expect(result.ok).toBe(true);
+
+    // The HTTP request body must carry the fiscal printType and printerId.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [, init] = global.fetch.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.printType).toBe('fiscal_receipt');
+    expect(body.printerId).toBe('fiscale');
+    expect(body.payments).toEqual([{ label: 'Contanti', amount: 13 }]);
+    expect(body.orders).toEqual(baseBill.orders);
+
+    // Existing pending entry (id rec-1) must be updated, not duplicated.
+    expect(storeStub.updateFiscalReceipt).toHaveBeenCalledWith('rec-1', expect.objectContaining({
+      fiscalReceiptNumber: '5',
+      serialNumber: '99IEB004001',
+      status: 'done',
+    }));
+    expect(storeStub.addFiscalReceipt).not.toHaveBeenCalled();
+  });
+
+  it('adds a new entry when no existing entry id matches', async () => {
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        ok: true,
+        fiscal: { success: true, code: '', status: '2', raw: '<r/>', addInfo: { fiscalReceiptNumber: '7' } },
+      }),
+    });
+
+    const result = await dispatchFiscalReceipt({ base: baseBill });
+    expect(result.ok).toBe(true);
+    expect(storeStub.addFiscalReceipt).toHaveBeenCalledTimes(1);
+    expect(storeStub.addFiscalReceipt.mock.calls[0][0]).toMatchObject({
+      fiscalReceiptNumber: '7',
+      status: 'done',
+    });
+  });
+
+  it('returns an error when the print-server reports failure', async () => {
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: false, error: 'Errore stampante fiscale: timeout' }),
+    });
+
+    const result = await dispatchFiscalReceipt({ base: baseBill });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('timeout');
+    expect(storeStub.addFiscalReceipt).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when no fiscal printer is configured', async () => {
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    const savedPrinters = storeStub.config.printers;
+    storeStub.config.printers = [{ id: 'demo', url: 'http://localhost:3001/print' }];
+    const result = await dispatchFiscalReceipt({ base: baseBill });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/nessuna stampante fiscale/i);
+    storeStub.config.printers = savedPrinters;
+  });
+
+  it('writes a FISCAL activity log entry on dispatch', async () => {
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    await dispatchFiscalReceipt({ base: baseBill });
+    await new Promise((r) => setTimeout(r, 0));
+    const logs = await getSyncLogs();
+    expect(logs.find((l) => l.type === 'FISCAL' && l.operation === 'fiscal_receipt')).toBeTruthy();
+  });
+});
+
+describe('dispatchFiscalZReport / dispatchFiscalStatus', () => {
+  it('sends a fiscal_z_report job', async () => {
+    const { dispatchFiscalZReport } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        ok: true,
+        fiscal: { success: true, code: '', status: '2', raw: '', addInfo: { zRepNumber: '11', dailyAmount: '332,33' } },
+      }),
+    });
+    const result = await dispatchFiscalZReport({});
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.printType).toBe('fiscal_z_report');
+    expect(body.printerId).toBe('fiscale');
+  });
+
+  it('sends a fiscal_status job with statusType', async () => {
+    const { dispatchFiscalStatus } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        ok: true,
+        fiscal: { success: true, code: '', status: '2', raw: '', addInfo: { fpStatus: '20010' } },
+      }),
+    });
+    const result = await dispatchFiscalStatus({ statusType: '1' });
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.printType).toBe('fiscal_status');
+    expect(body.statusType).toBe('1');
+  });
+});

--- a/src/composables/__tests__/useFiscalPrint.test.js
+++ b/src/composables/__tests__/useFiscalPrint.test.js
@@ -249,7 +249,23 @@ describe('dispatchFiscalVoid', () => {
     const { dispatchFiscalVoid } = await import('../useFiscalPrint.js');
     const result = await dispatchFiscalVoid({ receiptRef: {} });
     expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Riferimenti scontrino mancanti/);
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fails locally when any single reference field is missing', async () => {
+    // The server-side VOID formatter pads missing fields and would otherwise
+    // emit a VOID line referencing the wrong document, so every reference must
+    // be present and non-empty.
+    const { dispatchFiscalVoid } = await import('../useFiscalPrint.js');
+    const full = { zRepNumber: '39', fiscalReceiptNumber: '5', date: '31/01/2024', serialNumber: '99IEB004001' };
+    for (const field of ['zRepNumber', 'fiscalReceiptNumber', 'date', 'serialNumber']) {
+      const partial = { ...full, [field]: '' };
+      const result = await dispatchFiscalVoid({ receiptRef: partial });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain(field);
+      expect(global.fetch).not.toHaveBeenCalled();
+    }
   });
 });
 

--- a/src/composables/__tests__/useFiscalPrint.test.js
+++ b/src/composables/__tests__/useFiscalPrint.test.js
@@ -184,3 +184,118 @@ describe('dispatchFiscalZReport / dispatchFiscalStatus', () => {
     expect(body.statusType).toBe('1');
   });
 });
+
+// ── Void / Refund / Duplicate / Drawer / Cash ────────────────────────────────
+
+describe('dispatchFiscalVoid', () => {
+  it('sends a fiscal_void job carrying the receipt references', async () => {
+    const { dispatchFiscalVoid } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    const receiptRef = { zRepNumber: '39', fiscalReceiptNumber: '5', date: '31/01/2024', serialNumber: '99IEB004001' };
+    const result = await dispatchFiscalVoid({ receiptRef });
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.printType).toBe('fiscal_void');
+    expect(body.receiptRef).toEqual(receiptRef);
+    expect(body.printerId).toBe('fiscale');
+  });
+
+  it('fails locally when receipt references are missing', async () => {
+    const { dispatchFiscalVoid } = await import('../useFiscalPrint.js');
+    const result = await dispatchFiscalVoid({ receiptRef: {} });
+    expect(result.ok).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatchFiscalRefund', () => {
+  it('sends a fiscal_refund job with orders and payments', async () => {
+    const { dispatchFiscalRefund } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    const result = await dispatchFiscalRefund({ base: baseBill });
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.printType).toBe('fiscal_refund');
+    expect(body.orders).toEqual(baseBill.orders);
+    expect(body.payments[0].label).toBe('Contanti');
+  });
+
+  it('falls back to a single CONTANTI payment when paymentMethods is empty', async () => {
+    const { dispatchFiscalRefund } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    await dispatchFiscalRefund({ base: { orders: baseBill.orders, totalAmount: 13 } });
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.payments).toHaveLength(1);
+    expect(body.payments[0].label).toBe('CONTANTI');
+  });
+});
+
+describe('dispatchFiscalDuplicate / dispatchFiscalOpenDrawer', () => {
+  it('sends a fiscal_duplicate job', async () => {
+    const { dispatchFiscalDuplicate } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    const result = await dispatchFiscalDuplicate({});
+    expect(result.ok).toBe(true);
+    expect(JSON.parse(global.fetch.mock.calls[0][1].body).printType).toBe('fiscal_duplicate');
+  });
+
+  it('sends a fiscal_drawer job', async () => {
+    const { dispatchFiscalOpenDrawer } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    const result = await dispatchFiscalOpenDrawer({});
+    expect(result.ok).toBe(true);
+    expect(JSON.parse(global.fetch.mock.calls[0][1].body).printType).toBe('fiscal_drawer');
+  });
+});
+
+describe('dispatchFiscalCash', () => {
+  it('sends a fiscal_cash job with direction and amount', async () => {
+    const { dispatchFiscalCash } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    const result = await dispatchFiscalCash({ direction: 'out', amount: 50 });
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.printType).toBe('fiscal_cash');
+    expect(body.direction).toBe('out');
+    expect(body.amount).toBe(50);
+    expect(body.form).toBe('cash');
+  });
+
+  it('rejects an invalid direction locally', async () => {
+    const { dispatchFiscalCash } = await import('../useFiscalPrint.js');
+    const result = await dispatchFiscalCash({ direction: 'sideways', amount: 50 });
+    expect(result.ok).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-positive amount locally', async () => {
+    const { dispatchFiscalCash } = await import('../useFiscalPrint.js');
+    const result = await dispatchFiscalCash({ direction: 'in', amount: 0 });
+    expect(result.ok).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/__tests__/useFiscalPrint.test.js
+++ b/src/composables/__tests__/useFiscalPrint.test.js
@@ -147,6 +147,21 @@ describe('dispatchFiscalReceipt', () => {
     const logs = await getSyncLogs();
     expect(logs.find((l) => l.type === 'FISCAL' && l.operation === 'fiscal_receipt')).toBeTruthy();
   });
+
+  it('collapses multiple payment methods into a single payment to avoid overpaying', async () => {
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    const multiBill = { ...baseBill, paymentMethods: ['Contanti', 'Carta'], totalAmount: 20 };
+    await dispatchFiscalReceipt({ base: multiBill });
+    const [, init] = global.fetch.mock.calls[0];
+    const body = JSON.parse(init.body);
+    // One payment covering the whole total, not one-per-label summing to N×total.
+    expect(body.payments).toEqual([{ label: 'Contanti + Carta', amount: 20 }]);
+  });
 });
 
 describe('dispatchFiscalZReport / dispatchFiscalStatus', () => {

--- a/src/composables/__tests__/useFiscalPrint.test.js
+++ b/src/composables/__tests__/useFiscalPrint.test.js
@@ -10,8 +10,9 @@ import { getSyncLogs } from '../../store/persistence/syncLogs.js';
 
 // Mock the explicit layered stores used by useFiscalPrint. configStub carries
 // the runtime printers/hydration flag; orderStub carries fiscalReceipts and the
-// add/update mutators. Both are backed by the same shared array.
-const fiscalReceipts = { value: [] };
+// add/update mutators. fiscalReceipts is a plain array (Pinia auto-unwraps refs
+// on the store instance, so the composable/dashboard access it as an array).
+const fiscalReceipts = [];
 const configStub = {
   configHydrated: true,
   config: {
@@ -23,10 +24,10 @@ const configStub = {
 };
 const orderStub = {
   fiscalReceipts,
-  addFiscalReceipt: vi.fn((entry) => { orderStub.fiscalReceipts.value.unshift(entry); }),
+  addFiscalReceipt: vi.fn((entry) => { orderStub.fiscalReceipts.unshift(entry); }),
   updateFiscalReceipt: vi.fn((id, updates) => {
-    const idx = orderStub.fiscalReceipts.value.findIndex((e) => e.id === id);
-    if (idx !== -1) orderStub.fiscalReceipts.value[idx] = { ...orderStub.fiscalReceipts.value[idx], ...updates };
+    const idx = orderStub.fiscalReceipts.findIndex((e) => e.id === id);
+    if (idx !== -1) orderStub.fiscalReceipts[idx] = { ...orderStub.fiscalReceipts[idx], ...updates };
   }),
 };
 
@@ -41,7 +42,7 @@ beforeEach(async () => {
   await _resetIDBSingleton();
   vi.restoreAllMocks();
   global.fetch = vi.fn();
-  orderStub.fiscalReceipts.value = [];
+  orderStub.fiscalReceipts.length = 0;
   orderStub.addFiscalReceipt.mockClear();
   orderStub.updateFiscalReceipt.mockClear();
 });
@@ -62,7 +63,7 @@ describe('dispatchFiscalReceipt', () => {
     const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
     // Pre-populate the store with the pending entry, mirroring the real flow
     // where the component adds the pending entry before dispatching.
-    orderStub.fiscalReceipts.value = [{ id: 'rec-1', status: 'pending', ...baseBill }];
+    orderStub.fiscalReceipts = [{ id: 'rec-1', status: 'pending', ...baseBill }];
     global.fetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -151,7 +152,26 @@ describe('dispatchFiscalReceipt', () => {
     await dispatchFiscalReceipt({ base: baseBill });
     await new Promise((r) => setTimeout(r, 0));
     const logs = await getSyncLogs();
-    expect(logs.find((l) => l.type === 'FISCAL' && l.operation === 'fiscal_receipt')).toBeTruthy();
+    const entry = logs.find((l) => l.type === 'FISCAL' && l.operation === 'fiscal_receipt');
+    expect(entry).toBeTruthy();
+    // Activity logs use the sync-log vocabulary ('success'|'error'), not the
+    // fiscal lifecycle status 'done'.
+    expect(entry.status).toBe('success');
+  });
+
+  it('records an error status in the FISCAL activity log on failure', async () => {
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: false, error: 'Errore stampante fiscale: timeout' }),
+    });
+    await dispatchFiscalReceipt({ base: baseBill });
+    await new Promise((r) => setTimeout(r, 0));
+    const logs = await getSyncLogs();
+    const entry = logs.find((l) => l.type === 'FISCAL' && l.operation === 'fiscal_receipt');
+    expect(entry).toBeTruthy();
+    expect(entry.status).toBe('error');
   });
 
   it('collapses multiple payment methods into a single payment to avoid overpaying', async () => {

--- a/src/composables/__tests__/useFiscalPrint.test.js
+++ b/src/composables/__tests__/useFiscalPrint.test.js
@@ -8,8 +8,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { _resetIDBSingleton } from '../useIDB.js';
 import { getSyncLogs } from '../../store/persistence/syncLogs.js';
 
-// Mock the store so useAppStore returns a stub with fiscalReceipts + mutators.
-const storeStub = {
+// Mock the explicit layered stores used by useFiscalPrint. configStub carries
+// the runtime printers/hydration flag; orderStub carries fiscalReceipts and the
+// add/update mutators. Both are backed by the same shared array.
+const fiscalReceipts = { value: [] };
+const configStub = {
   configHydrated: true,
   config: {
     printers: [
@@ -17,16 +20,19 @@ const storeStub = {
       { id: 'fiscale', connectionType: 'fpmate', url: 'http://localhost:3001/print', printTypes: ['fiscal_receipt'] },
     ],
   },
-  fiscalReceipts: { value: [] },
-  addFiscalReceipt: vi.fn((entry) => { storeStub.fiscalReceipts.value.unshift(entry); }),
+};
+const orderStub = {
+  fiscalReceipts,
+  addFiscalReceipt: vi.fn((entry) => { orderStub.fiscalReceipts.value.unshift(entry); }),
   updateFiscalReceipt: vi.fn((id, updates) => {
-    const idx = storeStub.fiscalReceipts.value.findIndex((e) => e.id === id);
-    if (idx !== -1) storeStub.fiscalReceipts.value[idx] = { ...storeStub.fiscalReceipts.value[idx], ...updates };
+    const idx = orderStub.fiscalReceipts.value.findIndex((e) => e.id === id);
+    if (idx !== -1) orderStub.fiscalReceipts.value[idx] = { ...orderStub.fiscalReceipts.value[idx], ...updates };
   }),
 };
 
 vi.mock('../../store/index.js', () => ({
-  useAppStore: () => storeStub,
+  useConfigStore: () => configStub,
+  useOrderStore: () => orderStub,
 }));
 
 const ORIGINAL_FETCH = global.fetch;
@@ -35,9 +41,9 @@ beforeEach(async () => {
   await _resetIDBSingleton();
   vi.restoreAllMocks();
   global.fetch = vi.fn();
-  storeStub.fiscalReceipts.value = [];
-  storeStub.addFiscalReceipt.mockClear();
-  storeStub.updateFiscalReceipt.mockClear();
+  orderStub.fiscalReceipts.value = [];
+  orderStub.addFiscalReceipt.mockClear();
+  orderStub.updateFiscalReceipt.mockClear();
 });
 
 afterEach(() => {
@@ -56,7 +62,7 @@ describe('dispatchFiscalReceipt', () => {
     const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
     // Pre-populate the store with the pending entry, mirroring the real flow
     // where the component adds the pending entry before dispatching.
-    storeStub.fiscalReceipts.value = [{ id: 'rec-1', status: 'pending', ...baseBill }];
+    orderStub.fiscalReceipts.value = [{ id: 'rec-1', status: 'pending', ...baseBill }];
     global.fetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -83,12 +89,12 @@ describe('dispatchFiscalReceipt', () => {
     expect(body.orders).toEqual(baseBill.orders);
 
     // Existing pending entry (id rec-1) must be updated, not duplicated.
-    expect(storeStub.updateFiscalReceipt).toHaveBeenCalledWith('rec-1', expect.objectContaining({
+    expect(orderStub.updateFiscalReceipt).toHaveBeenCalledWith('rec-1', expect.objectContaining({
       fiscalReceiptNumber: '5',
       serialNumber: '99IEB004001',
       status: 'done',
     }));
-    expect(storeStub.addFiscalReceipt).not.toHaveBeenCalled();
+    expect(orderStub.addFiscalReceipt).not.toHaveBeenCalled();
   });
 
   it('adds a new entry when no existing entry id matches', async () => {
@@ -104,8 +110,8 @@ describe('dispatchFiscalReceipt', () => {
 
     const result = await dispatchFiscalReceipt({ base: baseBill });
     expect(result.ok).toBe(true);
-    expect(storeStub.addFiscalReceipt).toHaveBeenCalledTimes(1);
-    expect(storeStub.addFiscalReceipt.mock.calls[0][0]).toMatchObject({
+    expect(orderStub.addFiscalReceipt).toHaveBeenCalledTimes(1);
+    expect(orderStub.addFiscalReceipt.mock.calls[0][0]).toMatchObject({
       fiscalReceiptNumber: '7',
       status: 'done',
     });
@@ -122,17 +128,17 @@ describe('dispatchFiscalReceipt', () => {
     const result = await dispatchFiscalReceipt({ base: baseBill });
     expect(result.ok).toBe(false);
     expect(result.error).toContain('timeout');
-    expect(storeStub.addFiscalReceipt).not.toHaveBeenCalled();
+    expect(orderStub.addFiscalReceipt).not.toHaveBeenCalled();
   });
 
   it('returns an error when no fiscal printer is configured', async () => {
     const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
-    const savedPrinters = storeStub.config.printers;
-    storeStub.config.printers = [{ id: 'demo', url: 'http://localhost:3001/print' }];
+    const savedPrinters = configStub.config.printers;
+    configStub.config.printers = [{ id: 'demo', url: 'http://localhost:3001/print' }];
     const result = await dispatchFiscalReceipt({ base: baseBill });
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/nessuna stampante fiscale/i);
-    storeStub.config.printers = savedPrinters;
+    configStub.config.printers = savedPrinters;
   });
 
   it('writes a FISCAL activity log entry on dispatch', async () => {

--- a/src/composables/__tests__/useFiscalPrint.test.js
+++ b/src/composables/__tests__/useFiscalPrint.test.js
@@ -188,6 +188,24 @@ describe('dispatchFiscalReceipt', () => {
     // One payment covering the whole total, not one-per-label summing to N×total.
     expect(body.payments).toEqual([{ label: 'Contanti + Carta', amount: 20 }]);
   });
+
+  it('defaults the payment amount to 0 when totalAmount is undefined', async () => {
+    // A missing totalAmount would otherwise propagate as `amount: undefined`;
+    // the print-server filter (Number(amount) > 0) drops it and the job fails
+    // with "almeno un pagamento è obbligatorio". Fall back to 0 like the
+    // refund flow so the job is well-formed (and the server can validate).
+    const { dispatchFiscalReceipt } = await import('../useFiscalPrint.js');
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, fiscal: { success: true, code: '', status: '2', raw: '', addInfo: {} } }),
+    });
+    const baseNoTotal = { orders: baseBill.orders, paymentMethods: ['Contanti'] };
+    await dispatchFiscalReceipt({ base: baseNoTotal });
+    const [, init] = global.fetch.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.payments).toEqual([{ label: 'Contanti', amount: 0 }]);
+  });
 });
 
 describe('dispatchFiscalZReport / dispatchFiscalStatus', () => {
@@ -346,6 +364,7 @@ describe('dispatchFiscalCash', () => {
     const { dispatchFiscalCash } = await import('../useFiscalPrint.js');
     const result = await dispatchFiscalCash({ direction: 'sideways', amount: 50 });
     expect(result.ok).toBe(false);
+    expect(result.error).toBe('Direzione non valida (usare "in" o "out").');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 

--- a/src/composables/useFiscalPrint.js
+++ b/src/composables/useFiscalPrint.js
@@ -23,7 +23,7 @@
  */
 
 import { newUUIDv7 } from '../store/storeUtils.js';
-import { useAppStore } from '../store/index.js';
+import { useConfigStore, useOrderStore } from '../store/index.js';
 import {
   appConfig,
   PRINT_JOB_TYPES,
@@ -34,18 +34,22 @@ import { addSyncLog } from '../store/persistence/syncLogs.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function getStore() {
-  try {
-    return useAppStore();
-  } catch {
-    return null;
-  }
+// Use the explicit layered stores instead of the legacy useAppStore() merged
+// proxy (see src/store/index.js): dependencies stay explicit and mocking is
+// simpler. Outside a component/setup context (e.g. unit tests without an active
+// Pinia) these throw and we degrade gracefully to null.
+function getConfigStore() {
+  try { return useConfigStore(); } catch { return null; }
 }
 
-function getRuntimeConfig(store = null) {
-  const resolvedStore = store ?? getStore();
-  const storeConfig = resolvedStore?.config ?? {};
-  const storeHydrated = resolvedStore?.configHydrated === true;
+function getOrderStore() {
+  try { return useOrderStore(); } catch { return null; }
+}
+
+function getRuntimeConfig(configStore = null) {
+  const resolved = configStore ?? getConfigStore();
+  const storeConfig = resolved?.config ?? {};
+  const storeHydrated = resolved?.configHydrated === true;
   return storeHydrated
     ? { ...appConfig, ...storeConfig }
     : { ...storeConfig, ...appConfig };
@@ -53,11 +57,12 @@ function getRuntimeConfig(store = null) {
 
 /**
  * Resolves the configured fiscal printer (first fpmate printer with id+url).
- * @param {object|null} [store]
+ * @param {object|null} [configStore] - config store (or merged proxy); when
+ *   omitted, resolves the active config store at call time.
  * @returns {object|null}
  */
-export function resolveFiscalPrinter(store = null) {
-  return getFiscalPrinter(getRuntimeConfig(store).printers);
+export function resolveFiscalPrinter(configStore = null) {
+  return getFiscalPrinter(getRuntimeConfig(configStore).printers);
 }
 
 /**
@@ -119,8 +124,9 @@ function logFiscalActivity({ endpoint, payload, status, statusCode = null }) {
  * @returns {Promise<{ ok: boolean, entry?: object, error?: string }>}
  */
 export async function dispatchFiscalReceipt({ base, printerId = null, entry = null }) {
-  const store = getStore();
-  const printer = resolveFiscalPrinter(store);
+  const configStore = getConfigStore();
+  const orderStore = getOrderStore();
+  const printer = resolveFiscalPrinter(configStore);
   if (!printer) {
     return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
   }
@@ -174,11 +180,11 @@ export async function dispatchFiscalReceipt({ base, printerId = null, entry = nu
   };
   // When updating an existing pending entry (id already in the store), use
   // updateFiscalReceipt to avoid creating a duplicate; otherwise add a new one.
-  const existing = store?.fiscalReceipts?.value?.find((e) => e?.id === job.jobId);
+  const existing = orderStore?.fiscalReceipts?.value?.find((e) => e?.id === job.jobId);
   if (existing) {
-    store?.updateFiscalReceipt(job.jobId, updatedFields);
+    orderStore?.updateFiscalReceipt(job.jobId, updatedFields);
   } else {
-    store?.addFiscalReceipt({
+    orderStore?.addFiscalReceipt({
       id: job.jobId,
       ...base,
       ...updatedFields,
@@ -197,8 +203,8 @@ export async function dispatchFiscalReceipt({ base, printerId = null, entry = nu
  * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
  */
 export async function dispatchFiscalZReport({ printerId = null, operator } = {}) {
-  const store = getStore();
-  const printer = resolveFiscalPrinter(store);
+  const configStore = getConfigStore();
+  const printer = resolveFiscalPrinter(configStore);
   if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
 
   const job = {
@@ -224,8 +230,8 @@ export async function dispatchFiscalZReport({ printerId = null, operator } = {})
  * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
  */
 export async function dispatchFiscalXReport({ printerId = null, operator } = {}) {
-  const store = getStore();
-  const printer = resolveFiscalPrinter(store);
+  const configStore = getConfigStore();
+  const printer = resolveFiscalPrinter(configStore);
   if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
 
   const job = {
@@ -251,8 +257,8 @@ export async function dispatchFiscalXReport({ printerId = null, operator } = {})
  * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
  */
 export async function dispatchFiscalStatus({ printerId = null, statusType = '0' } = {}) {
-  const store = getStore();
-  const printer = resolveFiscalPrinter(store);
+  const configStore = getConfigStore();
+  const printer = resolveFiscalPrinter(configStore);
   if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
 
   const job = {
@@ -281,8 +287,8 @@ export async function dispatchFiscalStatus({ printerId = null, statusType = '0' 
  * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
  */
 async function dispatchFiscalJob({ printType, buildJob, printerId = null, operator } = {}) {
-  const store = getStore();
-  const printer = resolveFiscalPrinter(store);
+  const configStore = getConfigStore();
+  const printer = resolveFiscalPrinter(configStore);
   if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
 
   const job = buildJob(printer, operator);
@@ -337,10 +343,14 @@ export function dispatchFiscalRefund({ base, receiptRef = null, printerId = null
     printerId,
     operator,
     buildJob: (printer, op) => {
+      // Same rationale as dispatchFiscalReceipt: paymentMethods is a label set
+      // with no per-method amounts, so collapse into a single payment covering
+      // the whole refund total (otherwise the printer sums N×totalAmount).
       const paymentMethods = Array.isArray(base?.paymentMethods) ? base.paymentMethods : [];
-      const payments = paymentMethods.length > 0
-        ? paymentMethods.map((label) => ({ label, amount: base.totalAmount ?? 0 }))
-        : [{ label: 'CONTANTI', amount: base?.totalAmount ?? 0 }];
+      const payments = [{
+        label: paymentMethods.length > 0 ? paymentMethods.join(' + ') : 'CONTANTI',
+        amount: base?.totalAmount ?? 0,
+      }];
       return {
         jobId: newUUIDv7(),
         printType: PRINT_JOB_TYPES.FISCAL_REFUND,

--- a/src/composables/useFiscalPrint.js
+++ b/src/composables/useFiscalPrint.js
@@ -7,11 +7,16 @@
  * il browser invia solo i dati strutturati del job (printType, orders, payments).
  *
  * Funzioni esportate:
- *   dispatchFiscalReceipt({ base, printerId? })   – emette uno scontrino fiscale
- *   dispatchFiscalZReport({ printerId? })         – chiusura giornaliera (Z)
- *   dispatchFiscalXReport({ printerId? })         – report finanziario (X)
- *   dispatchFiscalStatus({ printerId?, statusType? }) – query stato stampante
- *   resolveFiscalPrinter()                        – restituisce la stampante fiscale configurata
+ *   dispatchFiscalReceipt({ base, printerId? })        – emette uno scontrino fiscale
+ *   dispatchFiscalRefund({ base, receiptRef?, printerId? }) – reso merce (REFUND)
+ *   dispatchFiscalVoid({ receiptRef, printerId? })     – annullo scontrino (VOID)
+ *   dispatchFiscalZReport({ printerId? })              – chiusura giornaliera (Z)
+ *   dispatchFiscalXReport({ printerId? })              – report finanziario (X)
+ *   dispatchFiscalStatus({ printerId?, statusType? })  – query stato stampante
+ *   dispatchFiscalDuplicate({ printerId? })            – ristampa ultimo scontrino
+ *   dispatchFiscalOpenDrawer({ printerId? })           – apertura cassetto
+ *   dispatchFiscalCash({ direction, amount, form?, printerId? }) – cash in/out
+ *   resolveFiscalPrinter()                             – restituisce la stampante fiscale configurata
  *
  * Ogni dispatch aggiorna la entry corrispondente in store (fiscalReceipts per gli
  * scontrini) con la risposta della stampante (fiscalReceiptNumber, amount, …).
@@ -259,4 +264,158 @@ export async function dispatchFiscalStatus({ printerId = null, statusType = '0' 
     status: result.ok ? PRINT_LOG_STATUSES.DONE : PRINT_LOG_STATUSES.ERROR,
   });
   return result;
+}
+
+// ── Void / Refund / Duplicate / Drawer / Cash ────────────────────────────────
+
+/**
+ * Helper per i job fiscali semplici (void, refund, duplicate, drawer, cash) che non
+ * richiedono aggiornamento di una entry fiscalReceipts specifica ma solo activity log.
+ * @param {{ printType: string, buildJob: (printer, operator) => object, printerId?: string|null, operator?: string|number }} args
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+async function dispatchFiscalJob({ printType, buildJob, printerId = null, operator } = {}) {
+  const store = getStore();
+  const printer = resolveFiscalPrinter(store);
+  if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
+
+  const job = buildJob(printer, operator);
+  const result = await sendFiscalJob({ job, printer });
+  logFiscalActivity({
+    endpoint: printer.url,
+    payload: job,
+    status: result.ok ? PRINT_LOG_STATUSES.DONE : PRINT_LOG_STATUSES.ERROR,
+  });
+  return result;
+}
+
+/**
+ * Emette un documento di annullo commerciale (VOID) per uno scontrino già emesso.
+ * I riferimenti (zRepNumber, fiscalReceiptNumber, date, serialNumber) sono recuperati
+ * dalla entry fiscalReceipts dell'originale (campi popolati dalla risposta fpmate).
+ *
+ * @param {{ receiptRef: object, printerId?: string|null, operator?: string|number }} options
+ *   receiptRef: { zRepNumber, fiscalReceiptNumber, date, serialNumber }
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export function dispatchFiscalVoid({ receiptRef, printerId = null, operator } = {}) {
+  if (!receiptRef || (!receiptRef.fiscalReceiptNumber && !receiptRef.zRepNumber)) {
+    return Promise.resolve({ ok: false, error: 'Riferimenti scontrino mancanti per l\'annullo.' });
+  }
+  return dispatchFiscalJob({
+    printType: PRINT_JOB_TYPES.FISCAL_VOID,
+    printerId,
+    operator,
+    buildJob: (printer, op) => ({
+      jobId: newUUIDv7(),
+      printType: PRINT_JOB_TYPES.FISCAL_VOID,
+      printerId: printerId ?? printer.id,
+      receiptRef,
+      timestamp: new Date().toISOString(),
+      ...(op != null ? { operator: op } : {}),
+    }),
+  });
+}
+
+/**
+ * Emette un documento di reso commerciale (REFUND / RESO MERCE). Le voci usano
+ * printRecRefund; se fornito receiptRef, la stampante collega il reso all'originale.
+ *
+ * @param {{ base: object, receiptRef?: object, printerId?: string|null, operator?: string|number }} options
+ *   base come in dispatchFiscalReceipt (orders, paymentMethods, totalAmount).
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export function dispatchFiscalRefund({ base, receiptRef = null, printerId = null, operator } = {}) {
+  return dispatchFiscalJob({
+    printType: PRINT_JOB_TYPES.FISCAL_REFUND,
+    printerId,
+    operator,
+    buildJob: (printer, op) => {
+      const paymentMethods = Array.isArray(base?.paymentMethods) ? base.paymentMethods : [];
+      const payments = paymentMethods.length > 0
+        ? paymentMethods.map((label) => ({ label, amount: base.totalAmount ?? 0 }))
+        : [{ label: 'CONTANTI', amount: base?.totalAmount ?? 0 }];
+      return {
+        jobId: newUUIDv7(),
+        printType: PRINT_JOB_TYPES.FISCAL_REFUND,
+        printerId: printerId ?? printer.id,
+        orders: base?.orders ?? [],
+        payments,
+        totalAmount: base?.totalAmount ?? 0,
+        ...(receiptRef ? { receiptRef } : {}),
+        timestamp: new Date().toISOString(),
+        ...(op != null ? { operator: op } : {}),
+      };
+    },
+  });
+}
+
+/**
+ * Ristampa l'ultimo scontrino commerciale emesso (duplicato, documento di gestione).
+ * @param {{ printerId?: string|null, operator?: string|number }} options
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export function dispatchFiscalDuplicate({ printerId = null, operator } = {}) {
+  return dispatchFiscalJob({
+    printType: PRINT_JOB_TYPES.FISCAL_DUPLICATE,
+    printerId,
+    operator,
+    buildJob: (printer, op) => ({
+      jobId: newUUIDv7(),
+      printType: PRINT_JOB_TYPES.FISCAL_DUPLICATE,
+      printerId: printerId ?? printer.id,
+      timestamp: new Date().toISOString(),
+      ...(op != null ? { operator: op } : {}),
+    }),
+  });
+}
+
+/**
+ * Apre il cassetto contanti collegato alla stampante fiscale.
+ * @param {{ printerId?: string|null, operator?: string|number }} options
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export function dispatchFiscalOpenDrawer({ printerId = null, operator } = {}) {
+  return dispatchFiscalJob({
+    printType: PRINT_JOB_TYPES.FISCAL_DRAWER,
+    printerId,
+    operator,
+    buildJob: (printer, op) => ({
+      jobId: newUUIDv7(),
+      printType: PRINT_JOB_TYPES.FISCAL_DRAWER,
+      printerId: printerId ?? printer.id,
+      timestamp: new Date().toISOString(),
+      ...(op != null ? { operator: op } : {}),
+    }),
+  });
+}
+
+/**
+ * Registra un movimento di cassa fiscale (versamento o prelievo) sulla stampante RT.
+ * @param {{ direction: 'in'|'out', amount: number, form?: 'cash'|'cheque', printerId?: string|null, operator?: string|number }} options
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export function dispatchFiscalCash({ direction, amount, form = 'cash', printerId = null, operator } = {}) {
+  const numAmount = Number(amount);
+  if (!['in', 'out'].includes(direction)) {
+    return Promise.resolve({ ok: false, error: 'Direction non valido (usare "in" o "out").' });
+  }
+  if (!Number.isFinite(numAmount) || numAmount <= 0) {
+    return Promise.resolve({ ok: false, error: 'Importo non valido per il movimento di cassa.' });
+  }
+  return dispatchFiscalJob({
+    printType: PRINT_JOB_TYPES.FISCAL_CASH,
+    printerId,
+    operator,
+    buildJob: (printer, op) => ({
+      jobId: newUUIDv7(),
+      printType: PRINT_JOB_TYPES.FISCAL_CASH,
+      printerId: printerId ?? printer.id,
+      direction,
+      amount: numAmount,
+      form,
+      timestamp: new Date().toISOString(),
+      ...(op != null ? { operator: op } : {}),
+    }),
+  });
 }

--- a/src/composables/useFiscalPrint.js
+++ b/src/composables/useFiscalPrint.js
@@ -126,11 +126,17 @@ export async function dispatchFiscalReceipt({ base, printerId = null, entry = nu
   }
   const resolvedPrinterId = printerId ?? printer.id;
 
-  // Build payments from the bill summary payment methods.
+  // Build payments from the bill summary payment methods. The bill summary
+  // exposes payment-method labels as a Set across transactions, but not the
+  // amount paid per method. Mapping each label to the full total would make the
+  // fiscal printer sum N×total and reject the receipt for inconsistent totals,
+  // so collapse the labels into a single payment covering the whole amount.
+  // The paymentType is derived server-side from the (possibly composite) label.
   const paymentMethods = Array.isArray(base.paymentMethods) ? base.paymentMethods : [];
-  const payments = paymentMethods.length > 0
-    ? paymentMethods.map((label) => ({ label, amount: base.totalAmount }))
-    : [{ label: 'CONTANTI', amount: base.totalAmount }];
+  const payments = [{
+    label: paymentMethods.length > 0 ? paymentMethods.join(' + ') : 'CONTANTI',
+    amount: base.totalAmount,
+  }];
 
   const job = {
     jobId: entry?.id ?? newUUIDv7(),

--- a/src/composables/useFiscalPrint.js
+++ b/src/composables/useFiscalPrint.js
@@ -1,0 +1,262 @@
+/**
+ * @file composables/useFiscalPrint.js
+ * @description Dispatch di job fiscali (scontrino, Z/X report, stato) verso la
+ * stampante fiscale Epson RT tramite il print-server.
+ *
+ * Il print-server costruisce l'XML Fiscal ePOS-Print e lo invia a fpmate.cgi;
+ * il browser invia solo i dati strutturati del job (printType, orders, payments).
+ *
+ * Funzioni esportate:
+ *   dispatchFiscalReceipt({ base, printerId? })   – emette uno scontrino fiscale
+ *   dispatchFiscalZReport({ printerId? })         – chiusura giornaliera (Z)
+ *   dispatchFiscalXReport({ printerId? })         – report finanziario (X)
+ *   dispatchFiscalStatus({ printerId?, statusType? }) – query stato stampante
+ *   resolveFiscalPrinter()                        – restituisce la stampante fiscale configurata
+ *
+ * Ogni dispatch aggiorna la entry corrispondente in store (fiscalReceipts per gli
+ * scontrini) con la risposta della stampante (fiscalReceiptNumber, amount, …).
+ */
+
+import { newUUIDv7 } from '../store/storeUtils.js';
+import { useAppStore } from '../store/index.js';
+import {
+  appConfig,
+  PRINT_JOB_TYPES,
+  PRINT_LOG_STATUSES,
+  getFiscalPrinter,
+} from '../utils/index.js';
+import { addSyncLog } from '../store/persistence/syncLogs.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function getStore() {
+  try {
+    return useAppStore();
+  } catch {
+    return null;
+  }
+}
+
+function getRuntimeConfig(store = null) {
+  const resolvedStore = store ?? getStore();
+  const storeConfig = resolvedStore?.config ?? {};
+  const storeHydrated = resolvedStore?.configHydrated === true;
+  return storeHydrated
+    ? { ...appConfig, ...storeConfig }
+    : { ...storeConfig, ...appConfig };
+}
+
+/**
+ * Resolves the configured fiscal printer (first fpmate printer with id+url).
+ * @param {object|null} [store]
+ * @returns {object|null}
+ */
+export function resolveFiscalPrinter(store = null) {
+  return getFiscalPrinter(getRuntimeConfig(store).printers);
+}
+
+/**
+ * Sends a fiscal job to the print-server and returns the parsed fiscal response.
+ *
+ * @param {{ job: object, printer: object }} options
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+async function sendFiscalJob({ job, printer }) {
+  const url = printer.url;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(job),
+    });
+    const text = await response.text();
+    let data;
+    try { data = text ? JSON.parse(text) : {}; } catch { data = { error: text }; }
+
+    if (response.ok && data.ok === true) {
+      return { ok: true, fiscal: data.fiscal ?? null };
+    }
+    const message = data?.error || `HTTP ${response.status}`;
+    return { ok: false, error: message };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? String(err) };
+  }
+}
+
+function logFiscalActivity({ endpoint, payload, status, statusCode = null }) {
+  addSyncLog({
+    direction: 'OUT',
+    type: 'FISCAL',
+    endpoint,
+    payload,
+    response: null,
+    status,
+    statusCode,
+    durationMs: 0,
+    collection: 'fiscal_receipts',
+    operation: payload?.printType ?? null,
+    method: 'POST',
+  });
+}
+
+// ── Fiscal receipt ──────────────────────────────────────────────────────────
+
+/**
+ * Emits a fiscal receipt (commercial document) for the given bill summary.
+ *
+ * @param {{
+ *   base: object,
+ *   printerId?: string|null,
+ *   entry?: object,        // existing fiscalReceipt entry to update (id, timestamp)
+ * }} options
+ *   `base` is the bill summary produced by _buildBillSummaryBase():
+ *     { orders: [{ items: [{ name, quantity, unitPrice }] }], paymentMethods: string[], totalAmount }
+ * @returns {Promise<{ ok: boolean, entry?: object, error?: string }>}
+ */
+export async function dispatchFiscalReceipt({ base, printerId = null, entry = null }) {
+  const store = getStore();
+  const printer = resolveFiscalPrinter(store);
+  if (!printer) {
+    return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
+  }
+  const resolvedPrinterId = printerId ?? printer.id;
+
+  // Build payments from the bill summary payment methods.
+  const paymentMethods = Array.isArray(base.paymentMethods) ? base.paymentMethods : [];
+  const payments = paymentMethods.length > 0
+    ? paymentMethods.map((label) => ({ label, amount: base.totalAmount }))
+    : [{ label: 'CONTANTI', amount: base.totalAmount }];
+
+  const job = {
+    jobId: entry?.id ?? newUUIDv7(),
+    printType: PRINT_JOB_TYPES.FISCAL_RECEIPT,
+    printerId: resolvedPrinterId,
+    orders: base.orders ?? [],
+    payments,
+    totalAmount: base.totalAmount ?? 0,
+    timestamp: entry?.timestamp ?? new Date().toISOString(),
+  };
+
+  const { ok, fiscal, error } = await sendFiscalJob({ job, printer });
+  logFiscalActivity({
+    endpoint: printer.url,
+    payload: job,
+    status: ok ? PRINT_LOG_STATUSES.DONE : PRINT_LOG_STATUSES.ERROR,
+  });
+
+  if (!ok) {
+    return { ok: false, error };
+  }
+
+  const addInfo = fiscal?.addInfo ?? {};
+  const updatedFields = {
+    xmlResponse: fiscal?.raw ?? null,
+    fiscalReceiptNumber: addInfo.fiscalReceiptNumber ?? null,
+    fiscalReceiptAmount: addInfo.fiscalReceiptAmount ?? null,
+    fiscalReceiptDate: addInfo.fiscalReceiptDate ?? null,
+    fiscalReceiptTime: addInfo.fiscalReceiptTime ?? null,
+    receiptISODateTime: addInfo.receiptISODateTime ?? null,
+    zRepNumber: addInfo.zRepNumber ?? null,
+    serialNumber: addInfo.serialNumber ?? null,
+    printerStatus: addInfo.printerStatus ?? null,
+    status: PRINT_LOG_STATUSES.DONE,
+  };
+  // When updating an existing pending entry (id already in the store), use
+  // updateFiscalReceipt to avoid creating a duplicate; otherwise add a new one.
+  const existing = store?.fiscalReceipts?.value?.find((e) => e?.id === job.jobId);
+  if (existing) {
+    store?.updateFiscalReceipt(job.jobId, updatedFields);
+  } else {
+    store?.addFiscalReceipt({
+      id: job.jobId,
+      ...base,
+      ...updatedFields,
+      timestamp: job.timestamp,
+    });
+  }
+  return { ok: true, entry: { ...(existing ?? {}), ...updatedFields, id: job.jobId } };
+}
+
+// ── Z / X reports ───────────────────────────────────────────────────────────
+
+/**
+ * Emits a daily closure (Z report). Data transmission to the tax authority
+ * happens automatically inside the fiscal printer.
+ * @param {{ printerId?: string|null, operator?: string|number }} options
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export async function dispatchFiscalZReport({ printerId = null, operator } = {}) {
+  const store = getStore();
+  const printer = resolveFiscalPrinter(store);
+  if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
+
+  const job = {
+    jobId: newUUIDv7(),
+    printType: PRINT_JOB_TYPES.FISCAL_Z_REPORT,
+    printerId: printerId ?? printer.id,
+    timestamp: new Date().toISOString(),
+  };
+  if (operator != null) job.operator = operator;
+
+  const result = await sendFiscalJob({ job, printer });
+  logFiscalActivity({
+    endpoint: printer.url,
+    payload: job,
+    status: result.ok ? PRINT_LOG_STATUSES.DONE : PRINT_LOG_STATUSES.ERROR,
+  });
+  return result;
+}
+
+/**
+ * Emits a daily financial report (X report — non fiscal).
+ * @param {{ printerId?: string|null, operator?: string|number }} options
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export async function dispatchFiscalXReport({ printerId = null, operator } = {}) {
+  const store = getStore();
+  const printer = resolveFiscalPrinter(store);
+  if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
+
+  const job = {
+    jobId: newUUIDv7(),
+    printType: PRINT_JOB_TYPES.FISCAL_X_REPORT,
+    printerId: printerId ?? printer.id,
+    timestamp: new Date().toISOString(),
+  };
+  if (operator != null) job.operator = operator;
+
+  const result = await sendFiscalJob({ job, printer });
+  logFiscalActivity({
+    endpoint: printer.url,
+    payload: job,
+    status: result.ok ? PRINT_LOG_STATUSES.DONE : PRINT_LOG_STATUSES.ERROR,
+  });
+  return result;
+}
+
+/**
+ * Queries the fiscal printer status (basic or RT).
+ * @param {{ printerId?: string|null, statusType?: '0'|'1' }} options
+ * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
+ */
+export async function dispatchFiscalStatus({ printerId = null, statusType = '0' } = {}) {
+  const store = getStore();
+  const printer = resolveFiscalPrinter(store);
+  if (!printer) return { ok: false, error: 'Nessuna stampante fiscale configurata.' };
+
+  const job = {
+    jobId: newUUIDv7(),
+    printType: PRINT_JOB_TYPES.FISCAL_STATUS,
+    printerId: printerId ?? printer.id,
+    statusType,
+    timestamp: new Date().toISOString(),
+  };
+
+  const result = await sendFiscalJob({ job, printer });
+  logFiscalActivity({
+    endpoint: printer.url,
+    payload: job,
+    status: result.ok ? PRINT_LOG_STATUSES.DONE : PRINT_LOG_STATUSES.ERROR,
+  });
+  return result;
+}

--- a/src/composables/useFiscalPrint.js
+++ b/src/composables/useFiscalPrint.js
@@ -152,7 +152,7 @@ export async function dispatchFiscalReceipt({ base, printerId = null, entry = nu
   const paymentMethods = Array.isArray(base.paymentMethods) ? base.paymentMethods : [];
   const payments = [{
     label: paymentMethods.length > 0 ? paymentMethods.join(' + ') : 'CONTANTI',
-    amount: base.totalAmount,
+    amount: base.totalAmount ?? 0,
   }];
 
   const job = {
@@ -437,7 +437,7 @@ export function dispatchFiscalOpenDrawer({ printerId = null, operator } = {}) {
 export function dispatchFiscalCash({ direction, amount, form = 'cash', printerId = null, operator } = {}) {
   const numAmount = Number(amount);
   if (!['in', 'out'].includes(direction)) {
-    return Promise.resolve({ ok: false, error: 'Direction non valido (usare "in" o "out").' });
+    return Promise.resolve({ ok: false, error: 'Direzione non valida (usare "in" o "out").' });
   }
   if (!Number.isFinite(numAmount) || numAmount <= 0) {
     return Promise.resolve({ ok: false, error: 'Importo non valido per il movimento di cassa.' });

--- a/src/composables/useFiscalPrint.js
+++ b/src/composables/useFiscalPrint.js
@@ -28,6 +28,7 @@ import {
   appConfig,
   PRINT_JOB_TYPES,
   PRINT_LOG_STATUSES,
+  PRINT_ACTIVITY_LOG_STATUSES,
   getFiscalPrinter,
 } from '../utils/index.js';
 import { addSyncLog } from '../store/persistence/syncLogs.js';
@@ -93,6 +94,16 @@ async function sendFiscalJob({ job, printer }) {
   }
 }
 
+// addSyncLog() records activity-log statuses ('success'|'error'), not the
+// print-job lifecycle statuses from PRINT_LOG_STATUSES ('pending'|'done'|
+// 'error'|...). Map the fiscal dispatch outcome to the activity-log vocabulary
+// so fiscal_receipts sync logs stay consistent with the rest of the app.
+function toActivityLogStatus(fiscalStatus) {
+  return fiscalStatus === PRINT_LOG_STATUSES.ERROR
+    ? PRINT_ACTIVITY_LOG_STATUSES.ERROR
+    : PRINT_ACTIVITY_LOG_STATUSES.SUCCESS;
+}
+
 function logFiscalActivity({ endpoint, payload, status, statusCode = null }) {
   addSyncLog({
     direction: 'OUT',
@@ -100,7 +111,7 @@ function logFiscalActivity({ endpoint, payload, status, statusCode = null }) {
     endpoint,
     payload,
     response: null,
-    status,
+    status: toActivityLogStatus(status),
     statusCode,
     durationMs: 0,
     collection: 'fiscal_receipts',
@@ -180,7 +191,8 @@ export async function dispatchFiscalReceipt({ base, printerId = null, entry = nu
   };
   // When updating an existing pending entry (id already in the store), use
   // updateFiscalReceipt to avoid creating a duplicate; otherwise add a new one.
-  const existing = orderStore?.fiscalReceipts?.value?.find((e) => e?.id === job.jobId);
+  // orderStore.fiscalReceipts is auto-unwrapped by Pinia to the array value.
+  const existing = orderStore?.fiscalReceipts?.find((e) => e?.id === job.jobId);
   if (existing) {
     orderStore?.updateFiscalReceipt(job.jobId, updatedFields);
   } else {

--- a/src/composables/useFiscalPrint.js
+++ b/src/composables/useFiscalPrint.js
@@ -323,8 +323,19 @@ async function dispatchFiscalJob({ printType, buildJob, printerId = null, operat
  * @returns {Promise<{ ok: boolean, fiscal?: object, error?: string }>}
  */
 export function dispatchFiscalVoid({ receiptRef, printerId = null, operator } = {}) {
-  if (!receiptRef || (!receiptRef.fiscalReceiptNumber && !receiptRef.zRepNumber)) {
-    return Promise.resolve({ ok: false, error: 'Riferimenti scontrino mancanti per l\'annullo.' });
+  // The server-side VOID formatter pads missing reference fields (zRepNumber→
+  // '0000', serialNumber padded with zeros, …) and still emits a VOID line, so
+  // an incomplete receiptRef would silently produce an annullo referencing the
+  // wrong document. Require all four references to be present and non-empty.
+  const REQUIRED_REF_FIELDS = ['zRepNumber', 'fiscalReceiptNumber', 'date', 'serialNumber'];
+  const missing = !receiptRef
+    ? REQUIRED_REF_FIELDS
+    : REQUIRED_REF_FIELDS.filter((k) => !receiptRef[k]);
+  if (missing.length) {
+    return Promise.resolve({
+      ok: false,
+      error: `Riferimenti scontrino mancanti per l'annullo (${missing.join(', ')}).`,
+    });
   }
   return dispatchFiscalJob({
     printType: PRINT_JOB_TYPES.FISCAL_VOID,

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -4,9 +4,11 @@ import {
   billKey,
   canPrinterReceiveJobs,
   formatOrderIdShort,
+  getFiscalPrinter,
   getPreBillEligiblePrinters,
   getPrintersForPrintType,
   getOrderItemRowTotal,
+  isFiscalPrinter,
   PRINT_JOB_TYPES,
   printerSupportsPrintType,
   resolveConfiguredPrinter,
@@ -68,6 +70,33 @@ describe('printer routing helpers', () => {
     expect(resolveConfiguredPrinter(printers, { printerId: 'b', printerUrl: 'http://localhost:3001/print' })?.id).toBe('b');
     expect(resolveConfiguredPrinter(printers, { printerUrl: 'http://localhost:3001/print' })?.id).toBe('a');
     expect(resolveConfiguredPrinter(printers, { printerId: 'missing' })).toBeNull();
+  });
+
+  it('identifies fiscal printers by connectionType', () => {
+    expect(isFiscalPrinter({ connectionType: 'fpmate' })).toBe(true);
+    expect(isFiscalPrinter({ connectionType: ' FPMATE ' })).toBe(true);
+    expect(isFiscalPrinter({ connectionType: 'tcp' })).toBe(false);
+    expect(isFiscalPrinter({ url: 'http://localhost:3001/print' })).toBe(false);
+    expect(isFiscalPrinter(null)).toBe(false);
+  });
+
+  it('returns the first valid fiscal printer with id and url', () => {
+    const printers = [
+      { id: 'demo', url: 'http://localhost:3001/print' },
+      { id: 'fiscale', connectionType: 'fpmate', url: 'http://localhost:3001/print', printTypes: ['fiscal_receipt'] },
+      { connectionType: 'fpmate', url: 'http://localhost:3001/print' }, // missing id
+      { id: 'fiscale2', connectionType: 'fpmate' }, // missing url
+    ];
+    expect(getFiscalPrinter(printers)?.id).toBe('fiscale');
+    expect(getFiscalPrinter([])).toBeNull();
+    expect(getFiscalPrinter(null)).toBeNull();
+  });
+
+  it('exposes fiscal print job type constants', () => {
+    expect(PRINT_JOB_TYPES.FISCAL_RECEIPT).toBe('fiscal_receipt');
+    expect(PRINT_JOB_TYPES.FISCAL_Z_REPORT).toBe('fiscal_z_report');
+    expect(PRINT_JOB_TYPES.FISCAL_X_REPORT).toBe('fiscal_x_report');
+    expect(PRINT_JOB_TYPES.FISCAL_STATUS).toBe('fiscal_status');
   });
 });
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -906,39 +906,3 @@ export function deepEqual(left, right) {
 export function resolveFiscalPrinter(printers) {
   return getFiscalPrinter(Array.isArray(printers) && printers.length ? printers : appConfig.printers);
 }
-
-/**
- * Builds the RT-printer XML payload for a fiscal receipt.
- *
- * This is the single, shared implementation used by both the live-cassa close
- * flow (CassaTableManager) and the post-close fiscal emission from the bill
- * history (CassaBillCard). Keeping it here ensures any future protocol tweaks
- * (e.g. per official RT-printer documentation) are applied in one place only.
- *
- * @param {object} base - Bill summary produced by `_buildBillSummaryBase()`.
- * @param {Array}  base.orders          - Orders with items (name, quantity, unitPrice).
- * @param {Array}  base.paymentMethods  - List of payment method labels.
- * @param {number} base.totalAmount     - Gross order total used as fiscal total.
- * @returns {string} XML string for the RT printer.
- */
-export function buildFiscalXmlRequest(base) {
-  const escXml = s => String(s).replace(/[<>&"']/g, c => (
-    { '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&apos;' }[c]
-  ));
-  const lines = base.orders.flatMap(o => o.items).map(item => {
-    const qty = item.quantity.toFixed(3);
-    const price = item.unitPrice.toFixed(2);
-    return `  <printRecItem description="${escXml(item.name)}" quantity="${qty}" unitPrice="${price}" department="1" />`;
-  });
-  const paymentType = base.paymentMethods.some(m => /cart|bancomat|pos|visa|master|carta/i.test(m)) ? '2' : '0';
-  const paymentLabel = escXml(base.paymentMethods.join(' + ') || 'CONTANTI');
-  const total = base.totalAmount.toFixed(2);
-  return [
-    '<printerFiscalReceipt>',
-    '  <beginFiscalReceipt operator="1" />',
-    ...lines,
-    `  <printRecTotal payment="${total}" paymentType="${paymentType}" description="${paymentLabel}" />`,
-    '  <endFiscalReceipt />',
-    '</printerFiscalReceipt>',
-  ].join('\n');
-}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -894,14 +894,17 @@ export function deepEqual(left, right) {
 
 
 /**
- * Resolves the configured fiscal printer against the runtime appConfig.
- * Convenience wrapper used by the UI to decide whether to dispatch a fiscal job
- * (no printer configured → the entry stays pending for later emission).
+ * Resolves the configured fiscal printer, preferring the runtime/hydrated
+ * printer list when provided. Used by the UI as a dispatch decision point: a
+ * fiscal printer is often configured at runtime via Directus/IDB config, so the
+ * static `appConfig.printers` alone yields false negatives.
  *
+ * @param {unknown} [printers] - runtime printer list (e.g. store config).
+ *   When omitted/null/empty, falls back to the static `appConfig.printers`.
  * @returns {object|null} the first fiscal printer with id+url, or null
  */
-export function resolveFiscalPrinter() {
-  return getFiscalPrinter(appConfig.printers);
+export function resolveFiscalPrinter(printers) {
+  return getFiscalPrinter(Array.isArray(printers) && printers.length ? printers : appConfig.printers);
 }
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -422,9 +422,14 @@ export const PRINT_JOB_TYPES = Object.freeze({
   TABLE_MOVE: 'table_move',
   PRE_BILL: 'pre_bill',
   FISCAL_RECEIPT: 'fiscal_receipt',
+  FISCAL_REFUND: 'fiscal_refund',
+  FISCAL_VOID: 'fiscal_void',
   FISCAL_Z_REPORT: 'fiscal_z_report',
   FISCAL_X_REPORT: 'fiscal_x_report',
   FISCAL_STATUS: 'fiscal_status',
+  FISCAL_DUPLICATE: 'fiscal_duplicate',
+  FISCAL_DRAWER: 'fiscal_drawer',
+  FISCAL_CASH: 'fiscal_cash',
 });
 
 export const DEFAULT_HTTP_PRE_BILL_PRINTER_ID = 'pre_bill';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -152,6 +152,14 @@ export const DEFAULT_SETTINGS = {
   // Stampante di prova (catch-all, riceve tutti i tipi e tutte le voci):
   // Attiva per default — punta al servizio Node ESC/POS locale sulla porta 3001.
   // Rimuovere o sostituire con la configurazione del locale prima del deployment in produzione.
+  //
+  // Stampante fiscale Epson RT (fpmate): aggiungere una voce con connectionType
+  // 'fpmate' e url del print-server. Il print-server costruisce l'XML fiscale e
+  // lo invia a fpmate.cgi; il browser non contatta direttamente la stampante.
+  //   { id: 'fiscale', name: 'Stampante Fiscale',
+  //     connectionType: 'fpmate',
+  //     url: 'http://localhost:3001/print',
+  //     printTypes: ['fiscal_receipt', 'fiscal_z_report', 'fiscal_x_report', 'fiscal_status'] }
   printers: [
     {
       id: 'demo',
@@ -413,9 +421,19 @@ export const PRINT_JOB_TYPES = Object.freeze({
   ORDER: 'order',
   TABLE_MOVE: 'table_move',
   PRE_BILL: 'pre_bill',
+  FISCAL_RECEIPT: 'fiscal_receipt',
+  FISCAL_Z_REPORT: 'fiscal_z_report',
+  FISCAL_X_REPORT: 'fiscal_x_report',
+  FISCAL_STATUS: 'fiscal_status',
 });
 
 export const DEFAULT_HTTP_PRE_BILL_PRINTER_ID = 'pre_bill';
+
+/**
+ * Connection type for Epson RT fiscal printers (fpmate.cgi HTTP/SOAP transport).
+ * Handled by the print-server, not the browser.
+ */
+export const FISCAL_PRINTER_CONNECTION_TYPE = 'fpmate';
 
 export const PRINT_LOG_STATUSES = Object.freeze({
   PENDING: 'pending',
@@ -443,6 +461,35 @@ export const PRINT_JOBS_COLLECTION = 'print_jobs';
 export function isDirectusManagedPrinter(printer) {
   const connectionType = getNormalizedPrinterConnectionType(printer);
   return connectionType === 'tcp' || connectionType === 'file';
+}
+
+/**
+ * Returns true when the printer is an Epson RT fiscal printer (fpmate.cgi).
+ * Fiscal printers are reached through the print-server, which builds the fiscal
+ * XML and dispatches it via HTTP/SOAP — the browser never talks to fpmate directly.
+ *
+ * @param {object|null|undefined} printer
+ * @returns {boolean}
+ */
+export function isFiscalPrinter(printer) {
+  return getNormalizedPrinterConnectionType(printer) === FISCAL_PRINTER_CONNECTION_TYPE;
+}
+
+/**
+ * Returns the first configured fiscal printer, or null if none is configured.
+ * A fiscal printer must have a stable id (used as printerId for the fiscal job)
+ * and a url pointing to the print-server `/print` endpoint.
+ *
+ * @param {unknown} printers
+ * @returns {object|null}
+ */
+export function getFiscalPrinter(printers) {
+  if (!Array.isArray(printers)) return null;
+  return printers.find((printer) =>
+    isFiscalPrinter(printer)
+    && typeof printer?.id === 'string' && printer.id.trim()
+    && typeof printer?.url === 'string' && printer.url.trim()
+  ) ?? null;
 }
 
 /**
@@ -840,6 +887,17 @@ export function deepEqual(left, right) {
   return true;
 }
 
+
+/**
+ * Resolves the configured fiscal printer against the runtime appConfig.
+ * Convenience wrapper used by the UI to decide whether to dispatch a fiscal job
+ * (no printer configured → the entry stays pending for later emission).
+ *
+ * @returns {object|null} the first fiscal printer with id+url, or null
+ */
+export function resolveFiscalPrinter() {
+  return getFiscalPrinter(appConfig.printers);
+}
 
 /**
  * Builds the RT-printer XML payload for a fiscal receipt.


### PR DESCRIPTION
> _This PR was created by an AI agent (OpenHands) on behalf of nzyhmunt._

## Riepilogo

Implementa la stampa dello scontrino fiscale su stampanti fiscali **EPSON RT** tramite il protocollo **ePOS Fiscal Print** (HTTP/SOAP XML via `fpmate.cgi`), integrandolo nel **print-server esistente** anziché creare un servizio Node.js separato.

### Scelta architetturale: riutilizzo del print-server

Il print-server è già il punto di smistamento dei job di stampa (ESC/POS TCP/file/HTTP) e gestisce coda serializzata per stampante, fallback e API HTTP. La stampante fiscale RT usa un protocollo diverso (SOAP/HTTP XML invece di ESC/POS raw), ma il flusso logico è identico: il server riceve il job, lo formatta e lo invia alla periferica. Aggiungere un quarto tipo di stampante (`fpmate`) al print-server esistente è quindi la soluzione più coerente e mantenibile: niente nuovo servizio, niente nuova porta, niente nuova coda da orchestrare.

## Modifiche

### print-server
- **`formatters/fiscal_receipt.js`** (nuovo) — `buildFiscalXml(job)`: genera l'XML Fiscal ePOS-Print per:
  - scontrino (`printerFiscalReceipt` con `beginFiscalReceipt`/`printRecItem`/`printRecTotal`/`endFiscalReceipt`)
  - Z report (`printZReport`), X report (`printXReport`), query stato (`queryPrinterStatus`)
  - separatori decimali italiani (virgola), escaping XML, default department/paymentType, righe header/trailer.
- **`fpmate-client.js`** (nuovo) — transport HTTP/SOAP per `fpmate.cgi`:
  - envelope SOAP, builder URL (`?timeout=`), header `If-Modified-Since`, parsing risposta (`success`/`code`/`status` + `addInfo`: numero scontrino, importo, data/ora, `zRepNumber`, `serialNumber`, `printerStatus`), gestione errori HTTP/network.
- **`printer.js`** — `loadPrintersFromEnv` supporta il tipo `fpmate` (host, port, https, timeout, username, password); `_dispatch` valida il tipo; `printViaFpmate` instrada al transport; esporta `printFiscal`.
- **`server.js`** — nuovi printType fiscali (`fiscal_receipt`, `fiscal_z_report`, `fiscal_x_report`, `fiscal_status`); `/print` instrada i job fiscali a `printFiscal` e restituisce la risposta parsata della stampante; endpoint `GET /printers`; log di avvio per le stampanti fpmate.
- **`printers.config.js` / `.env.example`** — documentazione del tipo `fpmate`.

### Frontend
- **`composables/useFiscalPrint.js`** (nuovo) — `dispatchFiscalReceipt` / `dispatchFiscalZReport` / `dispatchFiscalXReport` / `dispatchFiscalStatus`: individua la stampante fpmate configurata, invia il job strutturato (orders/payments), aggiorna `fiscalReceipts` con la risposta della stampante (numero scontrino, matricola, numero Z) e scrive un activity log FISCAL.
- **`utils/index.js`** — costanti `PRINT_JOB_TYPES` fiscali, `FISCAL_PRINTER_CONNECTION_TYPE`, helper `isFiscalPrinter`/`getFiscalPrinter`/`resolveFiscalPrinter`, esempio di stampante fiscale in `appConfig.printers`.
- **`CassaTableManager.vue` / `CassaBillCard.vue`** — emissione scontrino via print-server quando è configurata una stampante fpmate (XML costruito lato server, fonte unica); in caso di assenza di stampante fiscale o di errore, la entry resta `pending` per retry.

### Documentazione
- **`print-server/README.md`** — sezione stampante fiscale EPSON RT, risposte API fiscali, endpoint `/printers`, variabili d'ambiente, esempio integrazione app-cassa, struttura file.
- **`DATABASE_SCHEMA.md`** — campi risposta fpmate su `fiscal_receipts` (`fiscal_receipt_number`, `serial_number`, `z_rep_number`, …); campi `fpmate_*` e `connection_type='fpmate'` su `printers`.

## Test
- **print-server**: 91 test (formatter XML, parsing risposte fpmate, dispatch con server HTTP mock locale — serializzazione job, errori HTTP, validazione tipo). ✅
- **frontend**: 48 test (`getFiscalPrinter`/`isFiscalPrinter`, `useFiscalPrint` dispatch successo/errore/nessuna stampante/activity log). ✅
- **`vite build`**: build di produzione OK. ✅

> Note di sicurezza fiscale: i job fiscali sono serializzati per stampante (come gli altri job); la risposta della stampante viene persistita in `fiscal_receipts` per audit; il timeout (default 30s) è tenuto alto per lo Z report che trasmette dati all'Agenzia delle Entrate.

## Come configurare
1. Aggiungere al print-server una stampante `fpmate`:
   ```env
   PRINTER_3_ID=fiscale
   PRINTER_3_TYPE=fpmate
   PRINTER_3_HOST=192.168.1.200
   ```
2. Aggiungere in `appConfig.printers` (frontend) una voce con `connectionType: 'fpmate'` e `url: 'http://localhost:3001/print'`.
3. A chiusura conto, l'app emette lo scontrino fiscale automaticamente.

Riferimento protocollo: *ePOS Fiscal Print Solution Development Guide* (Epson Italia).

Closes #—